### PR TITLE
docs(docs): change component groupings

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -17,4 +17,11 @@ addons.setConfig({
     appBg: "white",
     appBorderColor: "white",
   }),
+  toolbar: {
+    title: { hidden: true },
+    zoom: { hidden: true },
+    eject: { hidden: true },
+    copy: { hidden: true },
+    fullscreen: { hidden: true },
+  },
 });

--- a/.storybook/pages/Landing.stories.mdx
+++ b/.storybook/pages/Landing.stories.mdx
@@ -120,6 +120,12 @@ In addition to the above, the following have provided feedback, ideas, and docum
       alt="Alex Trost"
     />
   </a>
+  <a href="https://twitter.com/chantastic" target="_blank">
+    <Avatar
+      src="https://www.chromatic.com/team/portraits-chan-square.png"
+      alt="Michael Chan"
+    />
+  </a>
 </Inline>
 
 ## Sponsor Bedrock Layouts

--- a/.storybook/pages/spacing.stories.mdx
+++ b/.storybook/pages/spacing.stories.mdx
@@ -70,7 +70,7 @@ Now that we have our first component that stacks elements in the block direction
   <span />
   <Button
     as="a"
-    href="/?path=/docs/getting-started-the-lesson-4-menu-component--page"
+    href="/?path=/docs/getting-started-lesson-4-the-menu-component--page"
   >
     The Menu Component
   </Button>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,7 +9,8 @@ export const parameters = {
       order: [
         "Overview",
         "Getting Started",
-        "Components",
+        "Spacer Components",
+        "Wrapper Components",
         "CSS Only",
         ["A CSS Only Version", "reset.css", "spacing-properties.css"],
         "Hooks",

--- a/packages/appboundary/examples/AppBoundary.stories.mdx
+++ b/packages/appboundary/examples/AppBoundary.stories.mdx
@@ -4,7 +4,7 @@ import { AppBoundary } from '@bedrock-layout/appboundary';
 
 import { argTypes } from './argTypes'
 
-<Meta title="Components/AppBoundary" component={AppBoundary} />
+<Meta title="Wrapper Components/AppBoundary" component={AppBoundary} />
 
 # AppBoundary
 

--- a/packages/center/examples/Center.stories.mdx
+++ b/packages/center/examples/Center.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview, Controls } from '@storybook/ad
 
 import { argTypes } from './argTypes'
 
-<Meta title="Components/Center" component={Center} />
+<Meta title="Wrapper Components/Center" component={Center} />
 
 # Center
 

--- a/packages/column-drop/examples/ColumnDrop.stories.mdx
+++ b/packages/column-drop/examples/ColumnDrop.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview } from '@storybook/addon-docs/'
 import { Box } from './Box';
 import { argTypes } from './argTypes'
 
-<Meta title="Components/ColumnDrop" component={ColumnDrop} />
+<Meta title="Spacer Components/ColumnDrop" component={ColumnDrop} />
 
 # ColumnDrop
 

--- a/packages/columns/examples/Columns.stories.mdx
+++ b/packages/columns/examples/Columns.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview, Controls } from '@storybook/ad
 import { Box } from './Box'
 import { columnsArgTypes, columnArgTypes } from './argTypes'
 
-<Meta title="Components/Columns" />
+<Meta title="Spacer Components/Columns" />
 
 # Columns
 

--- a/packages/cover/examples/Cover.stories.mdx
+++ b/packages/cover/examples/Cover.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview, Controls } from '@storybook/ad
 
 import { argTypes } from './argTypes'
 
-<Meta title="Components/Cover" component={Cover} />
+<Meta title="Wrapper Components/Cover" component={Cover} />
 
 # Cover
 

--- a/packages/css-reset/examples/CSSReset.stories.mdx
+++ b/packages/css-reset/examples/CSSReset.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable, Preview, Controls } from '@storybook/addon-docs/';
 
-<Meta title="Components/CSS Reset" />
+<Meta title="Wrapper Components/CSS Reset" />
 
 # CSS Reset
 

--- a/packages/frame/examples/Frame.stories.mdx
+++ b/packages/frame/examples/Frame.stories.mdx
@@ -5,7 +5,7 @@ import imgSrc from '../../../.storybook/assets/data-pic.jpg';
 
 import { argTypes } from './argTypes'
 
-<Meta title="Components/Frame" component={Frame} />
+<Meta title="Wrapper Components/Frame" component={Frame} />
 
 # Frame
 

--- a/packages/grid/examples/Grid.stories.mdx
+++ b/packages/grid/examples/Grid.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview, Controls } from '@storybook/ad
 import { Box } from './Box'
 import { argTypes } from './argTypes'
 
-<Meta title="Components/Grid" component={Grid} />
+<Meta title="Spacer Components/Grid" component={Grid} />
 
 # Grid
 

--- a/packages/inline-cluster/examples/InlineCluster.stories.mdx
+++ b/packages/inline-cluster/examples/InlineCluster.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview } from '@storybook/addon-docs/'
 import { Box } from './Box';
 import { argTypes } from './argTypes'
 
-<Meta title="Components/InlineCluster" component={InlineCluster} />
+<Meta title="Spacer Components/InlineCluster" component={InlineCluster} />
 
 # InlineCluster
 

--- a/packages/inline/examples/Inline.stories.mdx
+++ b/packages/inline/examples/Inline.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview } from '@storybook/addon-docs/'
 import { Box } from './Box';
 import { argTypes } from './argTypes'
 
-<Meta title="Components/Inline" component={Inline} />
+<Meta title="Spacer Components/Inline" component={Inline} />
 
 # Inline
 

--- a/packages/masonry-grid/examples/MasonryGrid.stories.mdx
+++ b/packages/masonry-grid/examples/MasonryGrid.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview } from '@storybook/addon-docs/'
 
 import { argTypes } from './argTypes'
 
-<Meta title="Components/MasonryGrid" component={MasonryGrid} />
+<Meta title="Spacer Components/MasonryGrid" component={MasonryGrid} />
 
 # MasonryGrid
 

--- a/packages/padbox/examples/PadBox.stories.mdx
+++ b/packages/padbox/examples/PadBox.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview, Controls } from '@storybook/ad
 
 import { argTypes, singleArgTypes, arrayArgTypes, objArgTypes } from './argTypes'
 
-<Meta title="Components/PadBox" component={PadBox} />
+<Meta title="Wrapper Components/PadBox" component={PadBox} />
 
 # PadBox
 

--- a/packages/reel/examples/Reel.stories.mdx
+++ b/packages/reel/examples/Reel.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview } from '@storybook/addon-docs/'
 
 import { colors, ColoredRect, argTypes} from './colors'
 
-<Meta title="Components/Reel" component={Reel} />
+<Meta title="Spacer Components/Reel" component={Reel} />
 
 # Reel
 

--- a/packages/split/examples/Split.stories.mdx
+++ b/packages/split/examples/Split.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview } from '@storybook/addon-docs/'
 import { Box } from './Box';
 import { argTypes } from './argTypes';
 
-<Meta title="Components/Split" component={Split} />
+<Meta title="Spacer Components/Split" component={Split} />
 
 # Split
 

--- a/packages/stack/examples/Stack.stories.mdx
+++ b/packages/stack/examples/Stack.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Canvas, ArgsTable, Preview, Controls } from '@storybook/ad
 import { Box } from './Box'
 import { argTypes } from './argTypes'
 
-<Meta title="Components/Stack" component={Stack} />
+<Meta title="Spacer Components/Stack" component={Stack} />
 
 # Stack
 


### PR DESCRIPTION
There are two many components, and it makes it much easier to understand from a high level what they
are for when grouped together.  We are grouping them based on being either Spacers or Wrappers