### PR TITLE
docs(docs): convert to using svg component

### DIFF
--- a/.storybook/pages/Landing.stories.mdx
+++ b/.storybook/pages/Landing.stories.mdx
@@ -13,12 +13,16 @@ import { Heading } from '../ui-components/Heading'
 import { Avatar } from '../ui-components/Avatar'
 import justLogo from '../assets/Logo only.svg'
 import fullLogo from '../assets/Full logo.png'
+import { LogoOnly } from '../ui-components/LogoOnly'
 
 <Meta title="Overview/Bedrock Layout Primitives" />
 
 <Stack gutter="xxl">
 <Cover minHeight="40vh">
   <Split gutter="lg" switchAt="60rem">
+     <Center>
+      <LogoOnly />
+    </Center>
     <Stack gutter='lg'>
       <Heading>
         BEDROCK
@@ -45,10 +49,6 @@ import fullLogo from '../assets/Full logo.png'
         </Button>
       </Inline>
     </Stack>
-    <Frame style={{transform:'scale(0.8)'}}>
-      <img src={justLogo} alt="Bedrock Layout Primitives" />
-    </Frame>
-
   </Split>
 </Cover>
 

--- a/.storybook/ui-components/LogoOnly.tsx
+++ b/.storybook/ui-components/LogoOnly.tsx
@@ -1,4 +1,8 @@
-    <svg height="256.8306010928962" viewBox="0, 0, 400, 256.8306010928962">
+import React from "react";
+
+export function LogoOnly({ style = {} }) {
+  return (
+    <svg height="256" viewBox="0, 0, 400, 256" style={style}>
       <g id="svgg">
         <path
           id="path1"
@@ -9,3 +13,5 @@
         ></path>
       </g>
     </svg>
+  );
+}


### PR DESCRIPTION
Switching the landing page to use an svg component.  This will allow dark theming to be easier.