### PR TITLE
fix(storybook): fix storybook deprecations

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,7 +8,7 @@ module.exports = {
     "./pages/menu.stories.mdx",
     "./pages/hero.stories.mdx",
     "./pages/new-arrivals.stories.mdx",
-    "../packages/**/examples/*.stories.(js|ts|tsx|mdx)",
+    "../packages/**/examples/*.stories.@(js|ts|tsx|mdx)",
     "./pages/contributing.stories.mdx",
     "../examples/examples.stories.mdx",
     "../examples/web.dev.stories.mdx",
@@ -18,4 +18,5 @@ module.exports = {
   core: {
     builder: "webpack5",
   },
+  staticDirs: ["../public"],
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Jarvis1010 <travis.mair@gmail.com>",
   "homepage": "https://bedrock-layout.dev/",
   "scripts": {
-    "start": "start-storybook -p 9001 -c .storybook -s ./public",
+    "start": "start-storybook -p 9001 -c .storybook",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch --notify",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cz": "cz",
     "clean": "lerna clean",
     "build": "lerna run build",
-    "build:storybook": "build-storybook -s ./public",
+    "build:storybook": "build-storybook",
     "prepublish": "yarn build",
     "publish": "lerna publish",
     "publish:ci": "yarn publish -- --no-commit-hooks --ignore-scripts",


### PR DESCRIPTION
Removes the deprecated [--static-dir flag](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag) and adds `staticDirs` to storybook's main.js file. Fixes [globs](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#correct-globs-in-mainjs) syntax.

Fixes #1077