### PR TITLE
feat(frame): allow ratio string in `ratio` prop

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,3 +24,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitZeroOnChanges: false

--- a/packages/frame/README.md
+++ b/packages/frame/README.md
@@ -42,7 +42,8 @@ For styling purposes, you can select `data-bedrock-frame`.
 
 ## API
 
-| Property | Description                                                                                                                   | Type               | Default           |
-| :------: | :---------------------------------------------------------------------------------------------------------------------------: | :----------------: | :---------------: |
-| ratio    | Aspect ratio that you want the child element to maintain                                                                      | `[number, number]` | medium breakpoint |
-| position | Alignment of the child element. Use [object-position value](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) | string             | `50%`             |
+∏
+| Property | Description | Type | Default |
+| :------: | :---------------------------------------------------------------------------------------------------------------------------: | :---------------: | :-------------------: | ----------------- |
+| ratio | Aspect ratio that you want the child element to maintain | `[number, number] | ${number}/${number}` | medium breakpoint |
+| position | Alignment of the child element. Use [object-position value](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) | string | `50%` |

--- a/packages/frame/__tests__/__snapshots__/frame.test.js.snap
+++ b/packages/frame/__tests__/__snapshots__/frame.test.js.snap
@@ -2,14 +2,15 @@
 
 exports[`Frame correct usage renders custom position 1`] = `
 .c0 {
-  --n: 16;
-  --d: 9;
   box-sizing: border-box;
   display: block;
   inline-size: 100%;
   position: relative;
   overflow: hidden;
-  aspect-ratio: var(--n) / var(--d);
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
 }
 
 .c0 > * {
@@ -51,6 +52,11 @@ exports[`Frame correct usage renders custom position 1`] = `
 <div
   className="c0"
   data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": "16/9",
+    }
+  }
 >
   <img
     alt="random thing"
@@ -59,16 +65,17 @@ exports[`Frame correct usage renders custom position 1`] = `
 </div>
 `;
 
-exports[`Frame correct usage renders with ratio 1`] = `
+exports[`Frame correct usage renders with ratio as a string 1`] = `
 .c0 {
-  --n: 16;
-  --d: 9;
   box-sizing: border-box;
   display: block;
   inline-size: 100%;
   position: relative;
   overflow: hidden;
-  aspect-ratio: var(--n) / var(--d);
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
 }
 
 .c0 > * {
@@ -110,6 +117,76 @@ exports[`Frame correct usage renders with ratio 1`] = `
 <div
   className="c0"
   data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": undefined,
+    }
+  }
+>
+  <img
+    alt="random thing"
+    src="https://picsum.photos/5000"
+  />
+</div>
+`;
+
+exports[`Frame correct usage renders with ratio as an array 1`] = `
+.c0 {
+  box-sizing: border-box;
+  display: block;
+  inline-size: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
+}
+
+.c0 > * {
+  position: absolute;
+  -webkit-inset-block-start: 0;
+  -ms-intb-rlock-start: 0;
+  inset-block-start: 0;
+  -webkit-inset-block-end: 0;
+  -ms-inlrock-end: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block: 0;
+  inset-inline: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 > :is(img,video) {
+  inline-size: 100%;
+  -webkit-block-size: 100%;
+  -ms-flex-block-size: 100%;
+  block-size: 100%;
+  size: 100%;
+  object-fit: cover;
+  object-position: 50%;
+}
+
+<div
+  className="c0"
+  data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": "16/9",
+    }
+  }
 >
   <img
     alt="random thing"
@@ -120,13 +197,15 @@ exports[`Frame correct usage renders with ratio 1`] = `
 
 exports[`Frame correct usage renders without ratio 1`] = `
 .c0 {
-  --n: 1;
-  --d: 1;
   box-sizing: border-box;
   display: block;
   inline-size: 100%;
   position: relative;
   overflow: hidden;
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
 }
 
 .c0 > * {
@@ -168,183 +247,11 @@ exports[`Frame correct usage renders without ratio 1`] = `
 <div
   className="c0"
   data-bedrock-frame=""
->
-  <img
-    alt="random thing"
-    src="https://picsum.photos/5000"
-  />
-</div>
-`;
-
-exports[`Frame incorrect usage falls back to 1 with error if array of length <1 provided 1`] = `
-.c0 {
-  --n: 16;
-  --d: 1;
-  box-sizing: border-box;
-  display: block;
-  inline-size: 100%;
-  position: relative;
-  overflow: hidden;
-  aspect-ratio: var(--n) / var(--d);
-}
-
-.c0 > * {
-  position: absolute;
-  -webkit-inset-block-start: 0;
-  -ms-intb-rlock-start: 0;
-  inset-block-start: 0;
-  -webkit-inset-block-end: 0;
-  -ms-inlrock-end: 0;
-  inset-block-end: 0;
-  inset-inline-start: 0;
-  inset-inline-end: 0;
-  inset-block: 0;
-  inset-inline: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c0 > :is(img,video) {
-  inline-size: 100%;
-  -webkit-block-size: 100%;
-  -ms-flex-block-size: 100%;
-  block-size: 100%;
-  size: 100%;
-  object-fit: cover;
-  object-position: 50%;
-}
-
-<div
-  className="c0"
-  data-bedrock-frame=""
->
-  <img
-    alt="random thing"
-    src="https://picsum.photos/5000"
-  />
-</div>
-`;
-
-exports[`Frame incorrect usage falls back to 1 with error if array of length >2 provided 1`] = `
-.c0 {
-  --n: 16;
-  --d: 9;
-  box-sizing: border-box;
-  display: block;
-  inline-size: 100%;
-  position: relative;
-  overflow: hidden;
-  aspect-ratio: var(--n) / var(--d);
-}
-
-.c0 > * {
-  position: absolute;
-  -webkit-inset-block-start: 0;
-  -ms-intb-rlock-start: 0;
-  inset-block-start: 0;
-  -webkit-inset-block-end: 0;
-  -ms-inlrock-end: 0;
-  inset-block-end: 0;
-  inset-inline-start: 0;
-  inset-inline-end: 0;
-  inset-block: 0;
-  inset-inline: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c0 > :is(img,video) {
-  inline-size: 100%;
-  -webkit-block-size: 100%;
-  -ms-flex-block-size: 100%;
-  block-size: 100%;
-  size: 100%;
-  object-fit: cover;
-  object-position: 50%;
-}
-
-<div
-  className="c0"
-  data-bedrock-frame=""
->
-  <img
-    alt="random thing"
-    src="https://picsum.photos/5000"
-  />
-</div>
-`;
-
-exports[`Frame incorrect usage falls back to 1 with error if array of not numbers provided 1`] = `
-.c0 {
-  --n: 1;
-  --d: 1;
-  box-sizing: border-box;
-  display: block;
-  inline-size: 100%;
-  position: relative;
-  overflow: hidden;
-  aspect-ratio: var(--n) / var(--d);
-}
-
-.c0 > * {
-  position: absolute;
-  -webkit-inset-block-start: 0;
-  -ms-intb-rlock-start: 0;
-  inset-block-start: 0;
-  -webkit-inset-block-end: 0;
-  -ms-inlrock-end: 0;
-  inset-block-end: 0;
-  inset-inline-start: 0;
-  inset-inline-end: 0;
-  inset-block: 0;
-  inset-inline: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c0 > :is(img,video) {
-  inline-size: 100%;
-  -webkit-block-size: 100%;
-  -ms-flex-block-size: 100%;
-  block-size: 100%;
-  size: 100%;
-  object-fit: cover;
-  object-position: 50%;
-}
-
-<div
-  className="c0"
-  data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": undefined,
+    }
+  }
 >
   <img
     alt="random thing"
@@ -355,14 +262,15 @@ exports[`Frame incorrect usage falls back to 1 with error if array of not number
 
 exports[`Frame incorrect usage renders default position with incorrect value 1`] = `
 .c0 {
-  --n: 16;
-  --d: 9;
   box-sizing: border-box;
   display: block;
   inline-size: 100%;
   position: relative;
   overflow: hidden;
-  aspect-ratio: var(--n) / var(--d);
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
 }
 
 .c0 > * {
@@ -404,6 +312,11 @@ exports[`Frame incorrect usage renders default position with incorrect value 1`]
 <div
   className="c0"
   data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": "16/9",
+    }
+  }
 >
   <img
     alt="random thing"
@@ -412,16 +325,17 @@ exports[`Frame incorrect usage renders default position with incorrect value 1`]
 </div>
 `;
 
-exports[`Frame incorrect usage renders ratio of 1:1 with error if ratio is not an array 1`] = `
+exports[`Frame incorrect usage renders without ratio if ratio is not correct type 1`] = `
 .c0 {
-  --n: 16;
-  --d: 9;
   box-sizing: border-box;
   display: block;
   inline-size: 100%;
   position: relative;
   overflow: hidden;
-  aspect-ratio: var(--n) / var(--d);
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
 }
 
 .c0 > * {
@@ -463,6 +377,271 @@ exports[`Frame incorrect usage renders ratio of 1:1 with error if ratio is not a
 <div
   className="c0"
   data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": undefined,
+    }
+  }
+>
+  <img
+    alt="random thing"
+    src="https://picsum.photos/5000"
+  />
+</div>
+`;
+
+exports[`Frame incorrect usage renders without ratio with error if array of length <1 provided 1`] = `
+.c0 {
+  box-sizing: border-box;
+  display: block;
+  inline-size: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
+}
+
+.c0 > * {
+  position: absolute;
+  -webkit-inset-block-start: 0;
+  -ms-intb-rlock-start: 0;
+  inset-block-start: 0;
+  -webkit-inset-block-end: 0;
+  -ms-inlrock-end: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block: 0;
+  inset-inline: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 > :is(img,video) {
+  inline-size: 100%;
+  -webkit-block-size: 100%;
+  -ms-flex-block-size: 100%;
+  block-size: 100%;
+  size: 100%;
+  object-fit: cover;
+  object-position: 50%;
+}
+
+<div
+  className="c0"
+  data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": undefined,
+    }
+  }
+>
+  <img
+    alt="random thing"
+    src="https://picsum.photos/5000"
+  />
+</div>
+`;
+
+exports[`Frame incorrect usage renders without ratio with error if array of length >2 provided 1`] = `
+.c0 {
+  box-sizing: border-box;
+  display: block;
+  inline-size: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
+}
+
+.c0 > * {
+  position: absolute;
+  -webkit-inset-block-start: 0;
+  -ms-intb-rlock-start: 0;
+  inset-block-start: 0;
+  -webkit-inset-block-end: 0;
+  -ms-inlrock-end: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block: 0;
+  inset-inline: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 > :is(img,video) {
+  inline-size: 100%;
+  -webkit-block-size: 100%;
+  -ms-flex-block-size: 100%;
+  block-size: 100%;
+  size: 100%;
+  object-fit: cover;
+  object-position: 50%;
+}
+
+<div
+  className="c0"
+  data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": undefined,
+    }
+  }
+>
+  <img
+    alt="random thing"
+    src="https://picsum.photos/5000"
+  />
+</div>
+`;
+
+exports[`Frame incorrect usage renders without ratio with error if array of not numbers provided 1`] = `
+.c0 {
+  box-sizing: border-box;
+  display: block;
+  inline-size: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
+}
+
+.c0 > * {
+  position: absolute;
+  -webkit-inset-block-start: 0;
+  -ms-intb-rlock-start: 0;
+  inset-block-start: 0;
+  -webkit-inset-block-end: 0;
+  -ms-inlrock-end: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block: 0;
+  inset-inline: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 > :is(img,video) {
+  inline-size: 100%;
+  -webkit-block-size: 100%;
+  -ms-flex-block-size: 100%;
+  block-size: 100%;
+  size: 100%;
+  object-fit: cover;
+  object-position: 50%;
+}
+
+<div
+  className="c0"
+  data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": undefined,
+    }
+  }
+>
+  <img
+    alt="random thing"
+    src="https://picsum.photos/5000"
+  />
+</div>
+`;
+
+exports[`Frame incorrect usage renders without ratio with error if ratio string is not correct format 1`] = `
+.c0 {
+  box-sizing: border-box;
+  display: block;
+  inline-size: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.c0[style*="--ratio"] {
+  aspect-ratio: var(--ratio);
+}
+
+.c0 > * {
+  position: absolute;
+  -webkit-inset-block-start: 0;
+  -ms-intb-rlock-start: 0;
+  inset-block-start: 0;
+  -webkit-inset-block-end: 0;
+  -ms-inlrock-end: 0;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block: 0;
+  inset-inline: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 > :is(img,video) {
+  inline-size: 100%;
+  -webkit-block-size: 100%;
+  -ms-flex-block-size: 100%;
+  block-size: 100%;
+  size: 100%;
+  object-fit: cover;
+  object-position: 50%;
+}
+
+<div
+  className="c0"
+  data-bedrock-frame=""
+  style={
+    Object {
+      "--ratio": undefined,
+    }
+  }
 >
   <img
     alt="random thing"

--- a/packages/frame/__tests__/__snapshots__/frame.test.js.snap
+++ b/packages/frame/__tests__/__snapshots__/frame.test.js.snap
@@ -119,7 +119,7 @@ exports[`Frame correct usage renders with ratio as a string 1`] = `
   data-bedrock-frame=""
   style={
     Object {
-      "--ratio": undefined,
+      "--ratio": "16/9",
     }
   }
 >

--- a/packages/frame/__tests__/frame.test.js
+++ b/packages/frame/__tests__/frame.test.js
@@ -9,9 +9,18 @@ describe("Frame", () => {
       expect(Frame).toBeTruthy();
     });
 
-    it("renders with ratio", () => {
+    it("renders with ratio as an array", () => {
       const frame = create(
         <Frame ratio={[16, 9]}>
+          <img src="https://picsum.photos/5000" alt="random thing" />
+        </Frame>
+      );
+      expect(frame.toJSON()).toMatchSnapshot();
+    });
+
+    it("renders with ratio as a string", () => {
+      const frame = create(
+        <Frame ratio="16/9">
           <img src="https://picsum.photos/5000" alt="random thing" />
         </Frame>
       );
@@ -59,7 +68,7 @@ describe("Frame", () => {
       expect(errorStack.toJSON()).toMatchSnapshot();
     });
 
-    it("renders ratio of 1:1 with error if ratio is not an array", () => {
+    it("renders without ratio if ratio is not correct type", () => {
       expect(console.error).not.toBeCalled();
 
       const errorStack = create(
@@ -72,7 +81,7 @@ describe("Frame", () => {
       expect(errorStack.toJSON()).toMatchSnapshot();
     });
 
-    it("falls back to 1 with error if array of length <1 provided", () => {
+    it("renders without ratio with error if array of length <1 provided", () => {
       expect(console.error).not.toBeCalled();
 
       const errorStack = create(
@@ -85,7 +94,7 @@ describe("Frame", () => {
       expect(errorStack.toJSON()).toMatchSnapshot();
     });
 
-    it("falls back to 1 with error if array of length >2 provided", () => {
+    it("renders without ratio with error if array of length >2 provided", () => {
       expect(console.error).not.toBeCalled();
 
       const errorStack = create(
@@ -98,11 +107,24 @@ describe("Frame", () => {
       expect(errorStack.toJSON()).toMatchSnapshot();
     });
 
-    it("falls back to 1 with error if array of not numbers provided", () => {
+    it("renders without ratio with error if array of not numbers provided", () => {
       expect(console.error).not.toBeCalled();
 
       const errorStack = create(
         <Frame ratio={["16", "9"]}>
+          <img src="https://picsum.photos/5000" alt="random thing" />
+        </Frame>
+      );
+
+      expect(console.error).toBeCalled();
+      expect(errorStack.toJSON()).toMatchSnapshot();
+    });
+
+    it("renders without ratio with error if ratio string is not correct format", () => {
+      expect(console.error).not.toBeCalled();
+
+      const errorStack = create(
+        <Frame ratio="16:9">
           <img src="https://picsum.photos/5000" alt="random thing" />
         </Frame>
       );

--- a/packages/frame/examples/Frame.stories.mdx
+++ b/packages/frame/examples/Frame.stories.mdx
@@ -25,14 +25,28 @@ yarn add @bedrock-layout/frame
 
 <ArgsTable story="API" />
 
-## ratio
+## ratio as string
 
-The `ratio` prop takes an array of two numbers, which prepresent the ratio of width to height of the desired aspect ratio.
+The `ratio` prop takes a string the is in the format of `${number}/${number}`, which represents the ratio of width to height of the desired aspect ratio.
+
+In the example below, the frame will maintain a 16:9 aspect ratio and will crop the image to fit.
+
+<Canvas withToolbar withSource="open">
+  <Story name="ratio as string">
+    <Frame ratio="16/9">
+      <img src={imgSrc} alt="computer with data" />
+    </Frame>
+  </Story>
+</Canvas>
+
+## ratio as array
+
+The `ratio` prop can also take an array of two numbers, which represent the ratio of width to height of the desired aspect ratio.
 
 In the example below, the frame will maintain a 4:3 aspect ratio and will crop the image to fit.
 
 <Canvas withToolbar withSource="open">
-  <Story name="ratio">
+  <Story name="ratio as array">
     <Frame ratio={[4, 3]}>
       <img src={imgSrc} alt="computer with data" />
     </Frame>

--- a/packages/frame/examples/argTypes.ts
+++ b/packages/frame/examples/argTypes.ts
@@ -3,7 +3,8 @@ export const argTypes = {
     description: "Aspect ratio that you want the child element to maintain",
     type: { name: "[number, number]" },
     table: {
-      type: { summary: "[number, number]" },
+      // eslint-disable-next-line no-template-curly-in-string
+      type: { summary: "[number, number] | `${number}/${number}`" },
     },
     control: "array",
   },

--- a/packages/frame/src/index.tsx
+++ b/packages/frame/src/index.tsx
@@ -15,7 +15,7 @@ function checkIsRatio(ratio: unknown): ratio is Ratio {
     Array.isArray(ratio) && ratio.length === 2 && ratio.every(Number.isFinite);
   return (
     isCorrectArray ||
-    (typeof ratio === "string" && /^\d{1,1000}\\\d{1,1000}$/.test(ratio))
+    (typeof ratio === "string" && /^\d{1,1000}\/\d{1,1000}$/.test(ratio))
   );
 }
 

--- a/packages/frame/src/index.tsx
+++ b/packages/frame/src/index.tsx
@@ -1,38 +1,50 @@
 import PropTypes from "prop-types";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
+
+type Ratio = [number, number] | `${number}/${number}`;
 
 export interface FrameProps {
-  ratio?: [number, number];
+  ratio?: Ratio;
   position?: string;
 }
 
-export const Frame = styled.div.attrs<FrameProps>(() => {
+type RatioString = `${number}/${number}`;
+
+function checkIsRatio(ratio: unknown): ratio is Ratio {
+  const isCorrectArray =
+    Array.isArray(ratio) && ratio.length === 2 && ratio.every(Number.isFinite);
+  return (
+    isCorrectArray ||
+    (typeof ratio === "string" && /^\d{1,1000}\\\d{1,1000}$/.test(ratio))
+  );
+}
+
+function getRatioString(ratio: Ratio): RatioString {
+  return Array.isArray(ratio) ? (ratio.join("/") as RatioString) : ratio;
+}
+
+function getSafeRatio(ratio: unknown): RatioString | undefined {
+  const isRatio = checkIsRatio(ratio);
+
+  return isRatio ? getRatioString(ratio) : undefined;
+}
+
+export const Frame = styled.div.attrs<FrameProps>(({ ratio, style }) => {
+  const safeRatio = getSafeRatio(ratio);
   return {
     "data-bedrock-frame": "",
+    style: { ...style, "--ratio": safeRatio },
   };
 })<FrameProps>`
-  --n: ${(props) =>
-    props.ratio && props.ratio[0] && Number.isInteger(props.ratio[0])
-      ? props.ratio[0]
-      : 1};
-
-  --d: ${(props) =>
-    props.ratio && props.ratio[1] && Number.isInteger(props.ratio[1])
-      ? props.ratio[1]
-      : 1};
-
   box-sizing: border-box;
   display: block;
   inline-size: 100%;
   position: relative;
   overflow: hidden;
 
-  ${(props) =>
-    props.ratio === undefined
-      ? ""
-      : css`
-          aspect-ratio: var(--n) / var(--d);
-        `}
+  &[style*="--ratio"] {
+    aspect-ratio: var(--ratio);
+  }
 
   > * {
     position: absolute;
@@ -63,22 +75,18 @@ export const Frame = styled.div.attrs<FrameProps>(() => {
 
 Frame.displayName = "Frame";
 
-type TwoNumbers = (props: FrameProps, propName: string) => Error | undefined;
-
-const twoNumbers: TwoNumbers = ({ ratio }, propName) => {
+function validateIsArray({ ratio }: FrameProps, propName: string) {
   if (ratio === undefined) return undefined;
-  if (
-    !Array.isArray(ratio) ||
-    ratio.length !== 2 ||
-    !ratio.every(Number.isInteger)
-  ) {
-    console.error(`${propName} needs to be an array of two numbers`);
+  const isRatio = checkIsRatio(ratio);
+  if (!isRatio) {
+    console.error(
+      `${propName} needs to be an array of two numbers or a string in the form of "width/height"`
+    );
   }
   return undefined;
-};
+}
 
 Frame.propTypes = {
-  //It's valid propType but can't get the type of Validator<[number, number]> to work
-  ratio: twoNumbers as unknown as React.Validator<[number, number]>,
+  ratio: validateIsArray as unknown as React.Validator<Ratio>,
   position: PropTypes.string,
 };

--- a/packages/primitives/__tests__/__snapshots__/primitives.test.js.snap
+++ b/packages/primitives/__tests__/__snapshots__/primitives.test.js.snap
@@ -294,23 +294,15 @@ Object {
       "isStatic": false,
       "rules": Array [
         "
-  --n: ",
-        [Function],
-        ";
-
-  --d: ",
-        [Function],
-        ";
-
   box-sizing: border-box;
   display: block;
   inline-size: 100%;
   position: relative;
   overflow: hidden;
 
-  ",
-        [Function],
-        "
+  &[style*=\\"--ratio\\"] {
+    aspect-ratio: var(--ratio);
+  }
 
   > * {
     position: absolute;

--- a/packages/primitives/examples/primitives.stories.mdx
+++ b/packages/primitives/examples/primitives.stories.mdx
@@ -14,7 +14,7 @@ The `@bedrock-layout/primitives` package includes all the primitives, hooks, and
 
 or
 
-`yarn add @bedrock-laylock/primitives`
+`yarn add @bedrock-layout/primitives`
 
 ---
 


### PR DESCRIPTION
To better align with CSS only version, Frame now accepts a ratio string in a width/height format