### PR TITLE
fix(inline): fix the bug with inline where switchAt wasn't working

### DIFF
--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -33,10 +33,6 @@ picture {
   max-inline-size: 100%;
 }
 
-.sbdocs-content.sbdocs-content {
-  width: revert;
-}
-
 html:focus-within {
   scroll-behavior: auto;
 }

--- a/examples/examples.stories.mdx
+++ b/examples/examples.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/';
+import { Meta, Story, Canvas } from '@storybook/addon-docs/';
 import { Stack } from '../packages/stack/src/';
 import { Frame } from '../packages/frame/src/';
 import { Columns, Column } from '../packages/columns/src/';
@@ -18,7 +18,7 @@ Minimal styling has been applied to make the examples more readable.
 
 A simple product card with an image and a description on the the right. Uses the `<Split>`, the `<Stack>`, and the `<PadBox>` components.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Product Card">
     <Split fraction="1/4" gutter="none">
       <img src={jacketPic} alt="Computer" />
@@ -41,7 +41,7 @@ A simple product card with an image and a description on the the right. Uses the
 
 A basic form with inputs that span multiple columns. Uses the `<Stack>`, `<Columns>` and the `<Column>` components.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Form">
     <Columns as="form" gutter="lg" columns={6}>
       <Column span={3}>
@@ -94,7 +94,7 @@ A basic form with inputs that span multiple columns. Uses the `<Stack>`, `<Colum
 
 A simple Avatar component. Uses the `<Frame>` component.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Avatar">
     <Frame
       ratio={[1, 1]}

--- a/examples/web.dev.stories.mdx
+++ b/examples/web.dev.stories.mdx
@@ -26,7 +26,7 @@ Maintains the aspect ratio of an image in a card, while letting you resize the c
 
 (The `<Center` component is used to center and clamp the width of the card in the example.)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Aspect ratio image card">
     <Center maxWidth="25rem">
       <PadBox
@@ -53,7 +53,7 @@ You can learn more about this pattern in the [clamping card](https://web.dev/lay
 
 At this time, Bedrock Layout Primitives does not have a layout component that would provide a benefit beyond what you can already do in CSS.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Clamping card">
     <Center centerChildren>
       <PadBox
@@ -80,7 +80,7 @@ Create a layout that stretches to fit the space, and snaps to the next line at a
 
 (The `<Center` component is used to center and clamp the width of the card in the example.)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Deconstructed pancake">
     <Center maxWidth="25rem">
       <ColumnDrop gutter="sm" basis="150px">
@@ -96,7 +96,7 @@ Create a layout that stretches to fit the space, and snaps to the next line at a
 
 Classic layout with a header, footer, and two sidebars flanking a main content area. Uses the `<Cover>` and `<Inline>` components.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Holy grail layout">
     <Cover
       gutter="sm"
@@ -120,7 +120,7 @@ A layout where the sidebar is given a minimum and maximum safe area size, and th
 
 (The `<Columns` component is used to create the 3 column layout.)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Line up">
     <Columns columns={3} gutter="xxl">
       <Cover
@@ -175,7 +175,7 @@ A layout where the sidebar is given a minimum and maximum safe area size, and th
 
 Commonly referred to as a sticky footer, this layout is often used for both websites and apps. Uses the `<Cover>` component.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Pancake stack">
     <Cover
       minHeight="25vh"
@@ -197,7 +197,7 @@ A responsive layout with automatically-placed and flexible children. Uses the `<
 
 (The `<Center` component is used to center and clamp the width of the card in the example.)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="RAM (Repeat, Auto, Minmax)">
     <Center maxWidth="25rem">
       <Grid gutter="lg" minItemWidth="150px">
@@ -214,7 +214,7 @@ A responsive layout with automatically-placed and flexible children. Uses the `<
 
 A layout where the sidebar is given a minimum and maximum safe area size, and the rest of the content fills the available space. Uses the `<Inline>` component.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Sidbar says">
     <Inline gutter="md" stretch={1} align="stretch">
       <Box contentEditable style={{ width: "max(100px, 25%)" }}>
@@ -232,7 +232,7 @@ A layout where the sidebar is given a minimum and maximum safe area size, and th
 
 Centering a child div vertically and horizontally. Uses the `<Center>` and `<Cover>` component.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Super centered">
     <Cover minHeight="25vh">
       <Center centerChildren>
@@ -246,7 +246,7 @@ Centering a child div vertically and horizontally. Uses the `<Center>` and `<Cov
 
 A grid broken up into 12 segments where you can place areas onto the tracks evenly. Uses the `<Columns>` and `<Column>` components.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="12-span grid">
     <Columns gutter="lg" columns={12}>
       <Column span={12}>

--- a/packages/appboundary/examples/AppBoundary.stories.mdx
+++ b/packages/appboundary/examples/AppBoundary.stories.mdx
@@ -28,7 +28,7 @@ yarn add @bedrock-layout/appboundary
 
 ## boundarySize
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="boundarySize">
     <h3>Default (xxlarge size)</h3>
     <AppBoundary>
@@ -124,7 +124,7 @@ export const Template = (args) =>  (
     </AppBoundary>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     argTypes={argTypes}

--- a/packages/bedrock-layout-css/examples/Stack.stories.mdx
+++ b/packages/bedrock-layout-css/examples/Stack.stories.mdx
@@ -34,7 +34,7 @@ The `--gutter` prop defines the gutter size between elements. Bedrock has implem
 
 You can adjust the space between the child elements by setting the `--gutter` property in the inline style.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--gutter">
     <h3>Bedrock Layout Spacing Property</h3>
     <div data-bedrock-stack style={{ "--gutter": "var(--space-md)" }}>

--- a/packages/bedrock-layout-css/examples/center.stories.mdx
+++ b/packages/bedrock-layout-css/examples/center.stories.mdx
@@ -33,7 +33,7 @@ You can adjust the max-width by setting the `--maxWidth` property in the inline 
 
 The below `--maxWidth` is set to `75%` of the parent component width.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--maxWidth">
     <div
       data-bedrock-center
@@ -57,7 +57,7 @@ The below `--maxWidth` is set to `75%` of the parent component width.
 
 You can also set the children to center by adding `center-children` to the `data-bedrock-center` attribute. This will center the children within the element.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="centerChildren">
     <div
       data-bedrock-center="center-children"
@@ -81,7 +81,7 @@ You can also set the children to center by adding `center-children` to the `data
 
 You can also set the text to center by adding `center-text` to the `data-bedrock-center` attribute. This will center the text within the element.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="centerText">
     <div
       data-bedrock-center="center-text"

--- a/packages/bedrock-layout-css/examples/column-drop.stories.mdx
+++ b/packages/bedrock-layout-css/examples/column-drop.stories.mdx
@@ -34,7 +34,7 @@ The `--gutter` prop defines the gutter size between elements. Bedrock has implem
 
 You can adjust the space between the child elements by setting the `--gutter` property in the inline style.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--gutter">
     <h3>Bedrock Layout Spacing Property</h3>
     <div
@@ -71,7 +71,7 @@ The grid will automatically optimize the number of columns based on the width of
 
 In the below example, The `--basis` is set to `15rem`. As you resize the window, the Grid will recalculate and potentially change the count of columns and rows.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--basis">
     <div
       data-bedrock-column-drop
@@ -95,7 +95,7 @@ By default, the column-drop component will stretch the columns to fit the contai
 
 In the below example, The `--basis` is set to `15rem`. As you resize the window, the Grid will recalculate and potentially change the count of columns and rows.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="no-stretched-columns">
     <div
       data-bedrock-column-drop="no-stretched-columns"

--- a/packages/bedrock-layout-css/examples/columns.stories.mdx
+++ b/packages/bedrock-layout-css/examples/columns.stories.mdx
@@ -32,7 +32,7 @@ Then you add the `data-bedrock-columns` and `data-bedrock-column` attributes to 
 
 The `--gutter` prop defines the gutter size between elements. Bedrock has implemented a [default spacing scheme](css-only-components-spacing-properties-css--page), or you can simply pass any valid CSS length or percentage value.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--gutter">
     <h3>Bedrock Layout Spacing Property</h3>
     <div
@@ -66,7 +66,7 @@ By default, the number of columns will be one. You can set the number of columns
 
 The below example is a 4 column layout. Each box will take up one column by default.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--columns">
     <div
       data-bedrock-columns
@@ -91,7 +91,7 @@ You can adjust the number of columns that the element spans by setting the `--sp
 
 The column component is wrapping the blue and green boxes. It is then setting the blue box to span 3 columns and the green to span 2
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--span">
     <div data-bedrock-columns style={{ "--gutter": "1rem", "--columns": 4 }}>
       <Box />
@@ -113,7 +113,7 @@ The column component is wrapping the blue and green boxes. It is then setting th
 
 You can choose to have a dense layout by setting the `dense` value on the `data-bedrock-columns` attribute.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="dense">
     <div
       data-bedrock-columns="dense"
@@ -140,7 +140,7 @@ If you want the have the element offset by `n` number of columns, before or afte
 
 In the below code, the blue box is `--offsetStart` of 1 and the green box has an `--offsetEnd` of 2
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="offsetStart and offsetEnd">
     <div data-bedrock-columns style={{ "--gutter": "1rem", "--columns": 4 }}>
       <Box />

--- a/packages/bedrock-layout-css/examples/cover.stories.mdx
+++ b/packages/bedrock-layout-css/examples/cover.stories.mdx
@@ -32,7 +32,7 @@ By default, the minimum height of the `data-bedrock-cover` element is `100vh`. Y
 
 (The below examples with the `--minHeight` prop set to `25vh`)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="data-bedrock-cover-centered">
     <h3>Centered element</h3>
     <div
@@ -97,7 +97,7 @@ This will ensure space between the elements if the content is larger than the `-
 
 (The below example, the `--minHeight` prop is set to `10vh` and the `--gutter` prop is set to `2rem`)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--gutter">
     <div
       data-bedrock-cover
@@ -125,7 +125,7 @@ The `--minHeight` custom property can be used to set the minimum height of the c
 
 (The below example, the `--minHeight` prop is set to `500px` and the `--gutter` prop is set to `2rem`)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--minHeight">
     <div
       data-bedrock-cover
@@ -153,7 +153,7 @@ Setting the `stretch-content` prop on the `data-bedrock-cover` attribute will st
 
 (The below example, the `--minHeight` prop is set to `50vh` and the `--gutter` prop is set to `2rem`)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="stretch-content">
     <div
       data-bedrock-cover="stretch-content"

--- a/packages/bedrock-layout-css/examples/frame.stories.mdx
+++ b/packages/bedrock-layout-css/examples/frame.stories.mdx
@@ -35,7 +35,7 @@ The `--ratio` prop takes a an ratio as a fraction, which prepresent the ratio of
 
 In the example below, the frame will maintain a 4:3 aspect ratio and will crop the image to fit.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--ratio">
     <div data-bedrock-frame style={{ "--ratio": "4/3" }}>
       <img src={imgSrc} alt="computer with data" />
@@ -49,7 +49,7 @@ By default, the media will be centered in the frame, but you can specify the pos
 
 In the example below, the frame will maintain a 4:3 aspect ratio and will crop the image to fit, but the image will be positioned at the top-left of the frame.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--position">
     <div
       data-bedrock-frame
@@ -66,7 +66,7 @@ You can also use the Frame without a ratio. This will allow you to specify the w
 
 In the example below, the frame's height is set to `50vh` and its width is set to `50%`. The image will be cropped to fit the frame.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="no ratio">
     <div data-bedrock-frame style={{ height: "50vh", width: "50%" }}>
       <img src={imgSrc} alt="computer with data" />

--- a/packages/bedrock-layout-css/examples/grid.stories.mdx
+++ b/packages/bedrock-layout-css/examples/grid.stories.mdx
@@ -34,7 +34,7 @@ The `--gutter` prop defines the gutter size between elements. Bedrock has implem
 
 You can adjust the space between the child elements by setting the `--gutter` property in the inline style.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--gutter">
     <h3>Bedrock Layout Spacing Property</h3>
     <div
@@ -71,7 +71,7 @@ The grid will automatically optimize the number of columns based on the width of
 
 In the below example, The `--minItemWidth` is set to `15rem`. As you resize the window, the Grid will recalculate and potentially change the count of columns and rows.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="minItemWidth">
     <div
       data-bedrock-grid

--- a/packages/bedrock-layout-css/examples/inline-cluster.stories.mdx
+++ b/packages/bedrock-layout-css/examples/inline-cluster.stories.mdx
@@ -32,7 +32,7 @@ Then you add the `data-bedrock-inline-cluster` attribute to the desired element.
 
 The `--gutter` prop defines the gutter size between elements. Bedrock has implemented a [default spacing scheme](css-only-components-spacing-properties-css--page), or you can simply pass any valid CSS length or percentage value.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--gutter">
     <h3>Bedrock Layout Spacing Property</h3>
     <div data-bedrock-inline-cluster style={{ "--gutter": "var(--space-md)" }}>
@@ -57,7 +57,7 @@ The `justify` prop defines the inline justification of the elements within the c
 
 You set the justification by setting the `justify` property on the `data-bedrock-inline` attribute.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="justify">
     <h3>justify:start</h3>
     <div
@@ -98,7 +98,7 @@ The `align` prop defines the block alignment of the elements within the cluster.
 
 You can set the alignment of the inline's children by setting the `align` property on the `data-bedrock-inline` attribute.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="align">
     <h3>align:start</h3>
     <div
@@ -159,7 +159,7 @@ The below example will stay inline unless they no longer have room in the contai
 
 (Resize your window to see this in action.)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="clustering">
     <h3>start</h3>
     <div

--- a/packages/bedrock-layout-css/examples/inline.stories.mdx
+++ b/packages/bedrock-layout-css/examples/inline.stories.mdx
@@ -33,7 +33,7 @@ Then you add the `data-bedrock-inline` attribute to the desired element.
 
 The `--gutter` prop defines the gutter size between elements. Bedrock has implemented a [default spacing scheme](css-only-components-spacing-properties-css--page), or you can simply pass any valid CSS length or percentage value.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--gutter">
     <h3>Bedrock Layout Spacing Property</h3>
     <div data-bedrock-inline style={{ "--gutter": "var(--space-md)" }}>
@@ -58,7 +58,7 @@ The `justify` prop defines the inline justification of the elements within the c
 
 You set the justification by setting the `justify` property on the `data-bedrock-inline` attribute.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="justify">
     <h3>justify:start</h3>
     <div data-bedrock-inline="justify:start" style={{ "--gutter": "2rem" }}>
@@ -90,7 +90,7 @@ The `align` prop defines the block alignment of the elements within the cluster.
 
 You can set the alignment of the inline's children by setting the `align` property on the `data-bedrock-inline` attribute.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="align">
     <h3>align:start</h3>
     <div data-bedrock-inline="align:start" style={{ "--gutter": "2rem" }}>
@@ -140,7 +140,7 @@ The `stretch` prop can be used to set one or all of the children to stretch and 
 
 The `stretch` prop accepts the following values: `stretch:start`, `stretch:end`, `stretch:all`.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="stretch">
     <h3>start</h3>
     <div data-bedrock-inline="stretch:start" style={{ "--gutter": "2rem" }}>
@@ -170,7 +170,7 @@ The `stretch` property can also be set with an integer that represents the index
 
 Unlike the `Inline` component, the `stretch` property can't be set to any integer value. The `stretch` property can only be set to 0-4 to represent the first, second, third, fourth, or fifth child respectively.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="stretch:index">
     <h3>0</h3>
     <div data-bedrock-inline="stretch:0" style={{ "--gutter": "2rem" }}>
@@ -221,7 +221,7 @@ If you set the `--switchAt` property, the inline will switch to a stacking layou
 
 The below example will switch to a stack when it is less than `45rem`. (Resize your window to see this in action.)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--switchAt">
     <div
       data-bedrock-inline

--- a/packages/bedrock-layout-css/examples/reel.stories.mdx
+++ b/packages/bedrock-layout-css/examples/reel.stories.mdx
@@ -35,7 +35,7 @@ The `--gutter` prop defines the gutter size between elements. Bedrock has implem
 
 You can adjust the space between the child elements by setting the `--gutter` property in the inline style.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--gutter">
     <h3>Bedrock Layout Spacing Property</h3>
     <div data-bedrock-reel style={{ "--gutter": "var(--space-md)" }}>
@@ -66,7 +66,7 @@ You can adjust the space between the child elements by setting the `--gutter` pr
 
 The `snapType` property sets the scroll snap type. The default snap type is `none`, but you can set it to `proximity` or `mandatory` by setting the `snapType:` value on the `data-bedrock-reel` attribute.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="snapType">
     <h3>none</h3>
     <p>scroll to the right to see the next item</p>

--- a/packages/bedrock-layout-css/examples/split.stories.mdx
+++ b/packages/bedrock-layout-css/examples/split.stories.mdx
@@ -34,7 +34,7 @@ The `--gutter` prop defines the gutter size between elements. Bedrock has implem
 
 You can adjust the space between the child elements by setting the `--gutter` property in the inline style.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="--gutter">
     <h3>Bedrock Layout Spacing Property</h3>
     <div data-bedrock-split style={{ "--gutter": "var(--space-md)" }}>
@@ -55,7 +55,7 @@ The `fraction` prop defines the fraction of the container width to use for the s
 
 By default the split will be a `1/2` split. You can change this by setting the `fraction:` value on the `data-bedrock-split` attribute.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="fraction">
     <h3>1/4</h3>
     <div data-bedrock-split="fraction:1/4" style={{ "--gutter": "1rem" }}>

--- a/packages/bedrock-layout-css/src/components/column-drop.css
+++ b/packages/bedrock-layout-css/src/components/column-drop.css
@@ -19,7 +19,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
 }
 
 [data-bedrock-column-drop] > * {

--- a/packages/bedrock-layout-css/src/components/cover.css
+++ b/packages/bedrock-layout-css/src/components/cover.css
@@ -17,7 +17,7 @@
 [data-bedrock-cover] {
   display: flex;
   flex-direction: column;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
 
   min-block-size: var(--minHeight, 100vh);
 }

--- a/packages/bedrock-layout-css/src/components/inline-cluster.css
+++ b/packages/bedrock-layout-css/src/components/inline-cluster.css
@@ -11,7 +11,7 @@
 [data-bedrock-inline-cluster] {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
   justify-content: flex-start;
   align-items: flex-start;
 }

--- a/packages/bedrock-layout-css/src/components/inline.css
+++ b/packages/bedrock-layout-css/src/components/inline.css
@@ -9,14 +9,14 @@
 
 @property --switchAt {
   syntax: "<length-percentage>";
-  inherits: false;
+  inherits: true;
   initial-value: 0;
 }
 
 [data-bedrock-inline] {
   display: flex;
   flex-wrap: nowrap;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
   justify-content: flex-start;
   align-items: flex-start;
 }
@@ -29,7 +29,7 @@
   flex-wrap: wrap;
 }
 [data-bedrock-inline][style*="--switchAt"] > * {
-  flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+  flex-basis: calc((var(--switchAt) - (100% - var(--gutter, 0px))) * 999);
 }
 
 [data-bedrock-inline~="justify:start"] {

--- a/packages/center/examples/Center.stories.mdx
+++ b/packages/center/examples/Center.stories.mdx
@@ -27,7 +27,7 @@ yarn add @bedrock-layout/center
 
 The Center component will clamp the width at a defined `maxWidth` and center itself in its context. Please note that the `maxWidth` prop represents the `max-width` of the children and not the Center component itself. In the example shown below, the `maxWidth` is set to `75%` of the parent component's width.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="maxWidth">
     <Center maxWidth="75%" style={{ border: "1px solid black" }}>
       <div>
@@ -48,7 +48,7 @@ The Center component will clamp the width at a defined `maxWidth` and center its
 
 You can also center the children by adding a `centerChildren` prop. Also, the max width of the children is set to 75%.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="centerChildren">
     <Center centerChildren style={{ border: "1px solid black" }}>
       <div style={{ width: "75%" }}>
@@ -69,7 +69,7 @@ You can also center the children by adding a `centerChildren` prop. Also, the ma
 
 You can also center the text by adding a `centerText` prop.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="centerText">
     <Center centerText centerChildren style={{ border: "1px solid black" }}>
       <div style={{ width: "75%" }}>
@@ -109,7 +109,7 @@ export const Template = (args) =>  (
   </Center>
 )
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     args={{

--- a/packages/column-drop/examples/ColumnDrop.stories.mdx
+++ b/packages/column-drop/examples/ColumnDrop.stories.mdx
@@ -30,7 +30,7 @@ The `gutter` prop defines the gutter size between elements. Bedrock has implemen
 
 The following values are available by default:
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="gutter">
     <h3>none</h3>
     <ColumnDrop gutter="none">
@@ -118,7 +118,7 @@ The `basis` prop defines the width basis of each of the children. The `ColumnDro
 
 In the below example, The `basis` is set to `15rem`. As you resize the window, the Grid will recalculate and potentially change the count of columns and rows.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="basis">
     <ColumnDrop gutter="lg" basis="15rem">
       <Box />
@@ -139,7 +139,7 @@ By default, the column-drop component will stretch the columns to fit the contai
 
 In the below example, The `basis` is set to `15rem`. As you resize the window, the ColumnDrop will recalculate and potentially change the count of columns and rows.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="noStretchedColumns">
     <ColumnDrop noStretchedColumns gutter="lg" basis="15rem">
       <Box />
@@ -174,7 +174,7 @@ export const Template = (args) =>  (
     </ColumnDrop>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     args={{

--- a/packages/columns/__tests__/__snapshots__/columns.test.js.snap
+++ b/packages/columns/__tests__/__snapshots__/columns.test.js.snap
@@ -7,7 +7,7 @@ exports[`Column correct usage renders as main 1`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -51,7 +51,7 @@ exports[`Column correct usage renders custom span 1`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -96,7 +96,7 @@ exports[`Column correct usage renders default gutters 1`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -140,7 +140,7 @@ exports[`Column correct usage renders offsetEnd span 1`] = `
   --columns: 4;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -194,7 +194,7 @@ exports[`Column correct usage renders offsetStart span 1`] = `
   --columns: 4;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -248,7 +248,7 @@ exports[`Column incorrect usage renders a span of 1 if given 0 1`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -293,7 +293,7 @@ exports[`Column incorrect usage renders a span of 1 if given negative number 1`]
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -338,7 +338,7 @@ exports[`Column incorrect usage renders default with console error with wrong sp
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -383,7 +383,7 @@ exports[`Columns correct usage renders all the gutter options 1`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -417,7 +417,7 @@ exports[`Columns correct usage renders all the gutter options 2`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -451,7 +451,7 @@ exports[`Columns correct usage renders all the gutter options 3`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -485,7 +485,7 @@ exports[`Columns correct usage renders all the gutter options 4`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -519,7 +519,7 @@ exports[`Columns correct usage renders all the gutter options 5`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -553,7 +553,7 @@ exports[`Columns correct usage renders all the gutter options 6`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -587,7 +587,7 @@ exports[`Columns correct usage renders all the gutter options 7`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -621,7 +621,7 @@ exports[`Columns correct usage renders all the gutter options 8`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -655,7 +655,7 @@ exports[`Columns correct usage renders all the gutter options 9`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -689,7 +689,7 @@ exports[`Columns correct usage renders all the gutter options 10`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -723,7 +723,7 @@ exports[`Columns correct usage renders all the gutter options 11`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -757,7 +757,7 @@ exports[`Columns correct usage renders custom columns 1`] = `
   --columns: 5;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -791,7 +791,7 @@ exports[`Columns correct usage renders dense mode 1`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row dense;
 }
 
@@ -825,7 +825,7 @@ exports[`Columns correct usage renders with theme overrides 1`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -857,7 +857,7 @@ exports[`Columns correct usage should render a columns if container is above swi
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -895,7 +895,7 @@ exports[`Columns correct usage should render a stack if container is below switc
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -935,7 +935,7 @@ exports[`Columns incorrect usage renders 1 columns if given 0 1`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -969,7 +969,7 @@ exports[`Columns incorrect usage renders 1 columns if given negative number 1`] 
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -1003,7 +1003,7 @@ exports[`Columns incorrect usage renders default with console error with incorre
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -1037,7 +1037,7 @@ exports[`Columns incorrect usage renders default with console error with incorre
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -1071,7 +1071,7 @@ exports[`Columns incorrect usage renders default with console error with no gutt
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -1105,7 +1105,7 @@ exports[`Columns incorrect usage renders default with console error with wrong s
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 
@@ -1139,7 +1139,7 @@ exports[`Columns incorrect usage renders default with wrong gutter input 1`] = `
   --columns: 1;
   display: grid;
   grid-template-columns: repeat(var(--columns),1fr);
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-auto-flow: row;
 }
 

--- a/packages/columns/examples/Columns.stories.mdx
+++ b/packages/columns/examples/Columns.stories.mdx
@@ -40,7 +40,7 @@ yarn add @bedrock-layout/columns
 
 The below example gives us a 4 column layout. By default, each box will take up one column.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="columns">
     <Columns gutter="lg" columns={4}>
       <Box />
@@ -58,7 +58,7 @@ The below example gives us a 4 column layout. By default, each box will take up 
 
 Gutters are configured with the `gutter` prop
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="gutters">
     <h3>none</h3>
     <Columns gutter="none" columns={4}>
@@ -163,7 +163,7 @@ Gutters are configured with the `gutter` prop
 
 Here, the `Column` component is wrapping the blue and green boxes. It is then setting the blue box to span 3 columns and the green to span 2
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="span">
     <Columns gutter="lg" columns={4}>
       <Box />
@@ -185,7 +185,7 @@ Here, the `Column` component is wrapping the blue and green boxes. It is then se
 
 Setting the `dense` prop will layout the children so that the items will fill any blank space.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="dense">
     <Columns dense gutter="lg" columns={4}>
       <Box>1</Box>
@@ -207,7 +207,7 @@ Setting the `dense` prop will layout the children so that the items will fill an
 
 In the example, the blue box has `offsetStart` prop with value of 1 and the green box has an `offsetEnd` prop with value of 2
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="offsetStart and offsetEnd">
     <Columns gutter="lg" columns={5}>
       <Box />
@@ -229,7 +229,7 @@ In the example, the blue box has `offsetStart` prop with value of 1 and the gree
 
 The below Columns layout will switch to a Stack layout when its less than `45rem`.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="switchAt">
     <Columns gutter="lg" columns={3} switchAt="45rem">
       <Box />
@@ -281,7 +281,7 @@ export const ColumnsTemplate = (args) =>  (
     </Columns>
 )
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Columns Playground"
     args={{
@@ -298,7 +298,7 @@ export const ColumnsTemplate = (args) =>  (
 
 <ArgsTable story="Columns Playground" />
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Column Playground"
     args={{

--- a/packages/columns/src/index.tsx
+++ b/packages/columns/src/index.tsx
@@ -35,7 +35,7 @@ const ColumnsBase = styled.div.attrs<ColumnsBaseProps>((props) => ({
 
   display: grid;
   grid-template-columns: repeat(var(--columns), 1fr);
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
   grid-auto-flow: row ${({ dense = false }) => (dense === true ? "dense" : "")};
 `;
 

--- a/packages/cover/examples/Cover.stories.mdx
+++ b/packages/cover/examples/Cover.stories.mdx
@@ -34,7 +34,7 @@ yarn add @bedrock-layout/cover
 
 The `Cover` component can be used with any React node as its child. The child will be vertically centered.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="With children">
     <Cover minHeight="50vh" gutter="sm">
       <div>
@@ -51,7 +51,7 @@ The `Cover` component can be used with any React node as its child. The child wi
 
 The `top` prop can be used to render a top section.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="top">
     <Cover minHeight="50vh" gutter="sm" top={<span>I am on top.</span>}>
       <div>
@@ -68,7 +68,7 @@ The `top` prop can be used to render a top section.
 
 The `bottom` prop can be used to render a bottom section.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="bottom">
     <Cover minHeight="50vh" gutter="sm" bottom={<span>I am on bottom.</span>}>
       <div>
@@ -85,7 +85,7 @@ The `bottom` prop can be used to render a bottom section.
 
 Both the `top` and `bottom` props can be used to render a top and bottom section.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="top and bottom">
     <Cover
       minHeight="50vh"
@@ -107,7 +107,7 @@ Both the `top` and `bottom` props can be used to render a top and bottom section
 
 The `minHeight` prop can be used to set the minimum height of the cover. The default is `100vh`.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="minHeight">
     <Cover
       minHeight="500px"
@@ -129,7 +129,7 @@ The `minHeight` prop can be used to set the minimum height of the cover. The def
 
 The `stretchContent` prop can be used to stretch the content to the full height of the `Cover` component. If there is a top or bottom section, the content will fill the remaining vertical space.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="stretchContent">
     <Cover
       minHeight="50vh"
@@ -167,7 +167,7 @@ export const Template = ({top, bottom,...args}) =>  (
     </Cover>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     args={{

--- a/packages/frame/examples/Frame.stories.mdx
+++ b/packages/frame/examples/Frame.stories.mdx
@@ -31,7 +31,7 @@ The `ratio` prop takes a string the is in the format of `${number}/${number}`, w
 
 In the example below, the frame will maintain a 16:9 aspect ratio and will crop the image to fit.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="ratio as string">
     <Frame ratio="16/9">
       <img src={imgSrc} alt="computer with data" />
@@ -45,7 +45,7 @@ The `ratio` prop can also take an array of two numbers, which represent the rati
 
 In the example below, the frame will maintain a 4:3 aspect ratio and will crop the image to fit.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="ratio as array">
     <Frame ratio={[4, 3]}>
       <img src={imgSrc} alt="computer with data" />
@@ -59,7 +59,7 @@ By default, the media will be centered in the frame, but you can specify the pos
 
 In the example below, the frame will maintain a 4:3 aspect ratio and will crop the image to fit, but the image will be positioned at the top-left of the frame.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="position">
     <Frame ratio={[4, 3]} position="left top">
       <img src={imgSrc} alt="computer with data" />
@@ -73,7 +73,7 @@ You can also use the Frame without a ratio. This will allow you to specify the w
 
 In the example below, the frame's height is set to `50vh` and its width is set to `50%`. The image will be cropped to fit the frame.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Without an Aspect Ratio">
     <Frame style={{ height: "50vh", width: "50%" }}>
       <img src={imgSrc} alt="computer with data" />
@@ -95,7 +95,7 @@ export const Template = (args) =>  (
     </Frame>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground with ratio"
     args={{
@@ -110,7 +110,7 @@ export const Template = (args) =>  (
 
 <ArgsTable story="Playground with ratio" />
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground without ratio"
     args={{

--- a/packages/grid/examples/Grid.stories.mdx
+++ b/packages/grid/examples/Grid.stories.mdx
@@ -32,7 +32,7 @@ The following values are available by default:
 
 (The `minItemWidth` is set to `25rem` in all the examples)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="gutter">
     <h3>none</h3>
     <Grid gutter="none" minItemWidth="25rem">
@@ -109,7 +109,7 @@ The `minItemWidth` prop defines the minimum width of each of the children. The `
 
 In the below example, The `minItemWidth` is set to `15rem`. As you resize the window, the Grid will recalculate and potentially change the count of columns and rows.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="minItemWidth">
     <Grid gutter="lg" minItemWidth="15rem">
       <Box />
@@ -145,7 +145,7 @@ export const Template = (args) =>  (
   </Grid>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     args={{ minItemWidth: "20rem", gutter: "lg" }}

--- a/packages/inline-cluster/__tests__/__snapshots__/inlineCluster.test.js.snap
+++ b/packages/inline-cluster/__tests__/__snapshots__/inlineCluster.test.js.snap
@@ -11,7 +11,7 @@ exports[`InlineCluster correct usage accepts className prop 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -56,7 +56,7 @@ exports[`InlineCluster correct usage renders all the align options 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -101,7 +101,7 @@ exports[`InlineCluster correct usage renders all the align options 2`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -146,7 +146,7 @@ exports[`InlineCluster correct usage renders all the align options 3`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -191,7 +191,7 @@ exports[`InlineCluster correct usage renders all the align options 4`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -236,7 +236,7 @@ exports[`InlineCluster correct usage renders all the gutter options 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -281,7 +281,7 @@ exports[`InlineCluster correct usage renders all the gutter options 2`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -326,7 +326,7 @@ exports[`InlineCluster correct usage renders all the gutter options 3`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -371,7 +371,7 @@ exports[`InlineCluster correct usage renders all the gutter options 4`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -416,7 +416,7 @@ exports[`InlineCluster correct usage renders all the gutter options 5`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -461,7 +461,7 @@ exports[`InlineCluster correct usage renders all the gutter options 6`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -506,7 +506,7 @@ exports[`InlineCluster correct usage renders all the gutter options 7`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -551,7 +551,7 @@ exports[`InlineCluster correct usage renders all the gutter options 8`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -596,7 +596,7 @@ exports[`InlineCluster correct usage renders all the gutter options 9`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -641,7 +641,7 @@ exports[`InlineCluster correct usage renders all the gutter options 10`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -686,7 +686,7 @@ exports[`InlineCluster correct usage renders all the gutter options 11`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -731,7 +731,7 @@ exports[`InlineCluster correct usage renders all the justify options 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -776,7 +776,7 @@ exports[`InlineCluster correct usage renders all the justify options 2`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -821,7 +821,7 @@ exports[`InlineCluster correct usage renders all the justify options 3`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
@@ -866,7 +866,7 @@ exports[`InlineCluster correct usage renders check for the browser 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -911,7 +911,7 @@ exports[`InlineCluster correct usage renders with theme overrides 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -956,7 +956,7 @@ exports[`InlineCluster correct usage renders with theme overrides using numbers 
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1001,7 +1001,7 @@ exports[`InlineCluster incorrect usage renders default with console error with i
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1046,7 +1046,7 @@ exports[`InlineCluster incorrect usage renders default with console error with i
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1091,7 +1091,7 @@ exports[`InlineCluster incorrect usage renders default with console error with n
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -1136,7 +1136,7 @@ exports[`InlineCluster incorrect usage renders default with wrong gutter input 1
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;

--- a/packages/inline-cluster/examples/InlineCluster.stories.mdx
+++ b/packages/inline-cluster/examples/InlineCluster.stories.mdx
@@ -30,7 +30,7 @@ The `gutter` prop defines the space between elements. Bedrock has implemented a 
 
 The following values are available by default:
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="gutter">
     <h3>none</h3>
     <InlineCluster gutter="none">
@@ -116,7 +116,7 @@ The following values are available by default:
 
 The `justify` prop defines the inline justification of the elements within the cluster. It accepts the following values: `start`, `end`, `center`, `stretch`.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="justify">
     <h3>start</h3>
     <InlineCluster justify="start" gutter="xl">
@@ -146,7 +146,7 @@ The `justify` prop defines the inline justification of the elements within the c
 
 The `align` prop defines the block alignment of the elements within the cluster. It accepts the following values: `start`, `end`, `center`, `stretch`.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="align">
     <h3>start</h3>
     <InlineCluster align="start" gutter="xl">
@@ -192,7 +192,7 @@ export const Template = (args) =>  (
     </InlineCluster>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     args={{

--- a/packages/inline-cluster/src/index.tsx
+++ b/packages/inline-cluster/src/index.tsx
@@ -45,7 +45,7 @@ export const InlineCluster = styled.div.attrs<InlineClusterProps>(
 
   display: flex;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
 
   justify-content: ${(props) =>
     typeof props.justify !== "undefined" && justifyMap[props.justify]

--- a/packages/inline/__tests__/__snapshots__/inline.test.js.snap
+++ b/packages/inline/__tests__/__snapshots__/inline.test.js.snap
@@ -11,7 +11,7 @@ exports[`Inline correct usage renders all the stretch options 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -45,9 +45,9 @@ exports[`Inline correct usage renders all the stretch options 1`] = `
 }
 
 .c1[style*="--switchAt"] > * {
-  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
 }
 
 <div
@@ -85,7 +85,7 @@ exports[`Inline correct usage renders all the stretch options 2`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -119,9 +119,9 @@ exports[`Inline correct usage renders all the stretch options 2`] = `
 }
 
 .c1[style*="--switchAt"] > * {
-  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
 }
 
 <div
@@ -159,7 +159,7 @@ exports[`Inline correct usage renders all the stretch options 3`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -193,9 +193,9 @@ exports[`Inline correct usage renders all the stretch options 3`] = `
 }
 
 .c1[style*="--switchAt"] > * {
-  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
 }
 
 <div
@@ -233,7 +233,7 @@ exports[`Inline correct usage renders all the stretch options 4`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -267,9 +267,9 @@ exports[`Inline correct usage renders all the stretch options 4`] = `
 }
 
 .c1[style*="--switchAt"] > * {
-  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
 }
 
 <div
@@ -307,7 +307,7 @@ exports[`Inline correct usage renders all the stretch options 5`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -341,9 +341,9 @@ exports[`Inline correct usage renders all the stretch options 5`] = `
 }
 
 .c1[style*="--switchAt"] > * {
-  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
 }
 
 <div
@@ -381,7 +381,7 @@ exports[`Inline correct usage renders with switchAt 1`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -409,9 +409,9 @@ exports[`Inline correct usage renders with switchAt 1`] = `
 }
 
 .c1[style*="--switchAt"] > * {
-  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
 }
 
 <div
@@ -449,7 +449,7 @@ exports[`Inline correct usage renders with switchAt 2`] = `
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -477,9 +477,9 @@ exports[`Inline correct usage renders with switchAt 2`] = `
 }
 
 .c1[style*="--switchAt"] > * {
-  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
 }
 
 <div
@@ -517,7 +517,7 @@ exports[`Inline incorrect usage renders default with console error with wrong st
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-box-pack: start;
   -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
@@ -545,9 +545,9 @@ exports[`Inline incorrect usage renders default with console error with wrong st
 }
 
 .c1[style*="--switchAt"] > * {
-  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
-  flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+  -webkit-flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  -ms-flex-preferred-size: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
+  flex-basis: calc((var(--switchAt) - (100% - var(--gutter,0px))) * 999);
 }
 
 <div

--- a/packages/inline/examples/Inline.stories.mdx
+++ b/packages/inline/examples/Inline.stories.mdx
@@ -31,7 +31,7 @@ The `Inline` component has all the same props as the `InlineCluster` component. 
 
 Below is an example of the `Inline` component with the `gutter` prop set to `xl` and both `justify` and `align` props set to `center`.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="InlineCluster Props">
     <Inline gutter="xl" justify="center" align="center">
       <Box style={{ height: 200 }} />
@@ -46,7 +46,7 @@ Below is an example of the `Inline` component with the `gutter` prop set to `xl`
 
 The `stretch` prop can be used to specify a child component that will stretch to fill the excess space.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="stretch">
     <h3>start</h3>
     <Inline gutter="lg" stretch="start">
@@ -83,7 +83,7 @@ The `stretch` prop can be used to specify a child component that will stretch to
 
 In the below example, the layout will switch to stack when its width becomes less than `45rem`. (Resize your window to see this in action.)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="switchAt">
     <Inline gutter="lg" switchAt="45rem">
       <Box />
@@ -111,7 +111,7 @@ export const Template = (args) =>  (
     </Inline>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     args={{

--- a/packages/inline/src/index.tsx
+++ b/packages/inline/src/index.tsx
@@ -44,6 +44,11 @@ export const Inline = styled(InlineCluster).attrs<InlineProps>(
     };
   }
 )<InlineProps>`
+  @property --switchAt {
+    syntax: "<length-percentage>";
+    inherits: true;
+    initial-value: 0;
+  }
   flex-wrap: nowrap;
   ${({ stretch }) =>
     stretch === "all"
@@ -59,7 +64,7 @@ export const Inline = styled(InlineCluster).attrs<InlineProps>(
   &[style*="--switchAt"] {
     flex-wrap: wrap;
     > * {
-      flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+      flex-basis: calc((var(--switchAt) - (100% - var(--gutter, 0px))) * 999);
     }
   }
 `;

--- a/packages/masonry-grid/examples/MasonryGrid.stories.mdx
+++ b/packages/masonry-grid/examples/MasonryGrid.stories.mdx
@@ -27,7 +27,7 @@ yarn add @bedrock-layout/masonry-grid
 
 In the below examples, the `minItemWidth` is set to `15rem` with `gutter` set to `lg`. (Resize your window to see the items update.)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Basic">
     <MasonryGrid gutter="lg" minItemWidth="15rem">
       <div>
@@ -159,7 +159,7 @@ export const Template = (args) =>  (
     </MasonryGrid>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     args={{ minItemWidth: "25rem", gutter: "lg" }}

--- a/packages/padbox/examples/PadBox.stories.mdx
+++ b/packages/padbox/examples/PadBox.stories.mdx
@@ -28,7 +28,7 @@ yarn add @bedrock-layout/padbox
 
 `padding` can take a single value for a consistent box shape padding.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Basic">
     <h3>none</h3>
     <PadBox style={{ border: "1px solid black" }} padding="none">
@@ -114,7 +114,7 @@ yarn add @bedrock-layout/padbox
 
 `padding` can take an array that follows the [padding short hand rules](https://developer.mozilla.org/en-US/docs/Web/CSS/padding).
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="With an array">
     <h3>With 2 values</h3>
     <pre>["md", "xl"]</pre>
@@ -152,7 +152,7 @@ The `padding` prop can also take an object to specify which locations will have 
 You can pass either traditional properties like `top, bottom, right, left`, or logical properties in camelcase such as `blockStart, blockEnd, inlineStart, inlineEnd`.
 No matter which properties are given, logical properties are used.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="With an object">
     <h3>With an object of values</h3>
     <pre>
@@ -196,7 +196,7 @@ export const Template = (args) =>  (
     </PadBox>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     args={{
@@ -210,7 +210,7 @@ export const Template = (args) =>  (
 
 <ArgsTable story="Playground" />
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground with array"
     args={{
@@ -224,7 +224,7 @@ export const Template = (args) =>  (
 
 <ArgsTable story="Playground with array" />
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground with object"
     args={{

--- a/packages/primitives/__tests__/__snapshots__/primitives.test.js.snap
+++ b/packages/primitives/__tests__/__snapshots__/primitives.test.js.snap
@@ -435,7 +435,7 @@ Object {
 
   display: flex;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
 
   justify-content: ",
           [Function],
@@ -452,6 +452,11 @@ Object {
       "isStatic": false,
       "rules": Array [
         "
+  @property --switchAt {
+    syntax: \\"<length-percentage>\\";
+    inherits: true;
+    initial-value: 0;
+  }
   flex-wrap: nowrap;
   ",
         [Function],
@@ -460,7 +465,7 @@ Object {
   &[style*=\\"--switchAt\\"] {
     flex-wrap: wrap;
     > * {
-      flex-basis: calc((var(--switchAt) - (100% - var(--gutter))) * 999);
+      flex-basis: calc((var(--switchAt) - (100% - var(--gutter, 0px))) * 999);
     }
   }
 ",
@@ -508,7 +513,7 @@ Object {
 
   display: flex;
   flex-wrap: wrap;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
 
   justify-content: ",
         [Function],
@@ -691,7 +696,7 @@ Object {
         ";
 
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
   align-content: start;
 
   & > [data-bedrock-column] {

--- a/packages/reel/__tests__/__snapshots__/reel.test.js.snap
+++ b/packages/reel/__tests__/__snapshots__/reel.test.js.snap
@@ -7,7 +7,7 @@ exports[`Reel correct usage renders all the gutter options 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -51,7 +51,7 @@ exports[`Reel correct usage renders all the gutter options 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -95,7 +95,7 @@ exports[`Reel correct usage renders all the gutter options 3`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -139,7 +139,7 @@ exports[`Reel correct usage renders all the gutter options 4`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -183,7 +183,7 @@ exports[`Reel correct usage renders all the gutter options 5`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -227,7 +227,7 @@ exports[`Reel correct usage renders all the gutter options 6`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -271,7 +271,7 @@ exports[`Reel correct usage renders all the gutter options 7`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -315,7 +315,7 @@ exports[`Reel correct usage renders all the gutter options 8`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -359,7 +359,7 @@ exports[`Reel correct usage renders all the gutter options 9`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -403,7 +403,7 @@ exports[`Reel correct usage renders all the gutter options 10`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -447,7 +447,7 @@ exports[`Reel correct usage renders all the gutter options 11`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -491,7 +491,7 @@ exports[`Reel correct usage renders snapTypes 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -535,7 +535,7 @@ exports[`Reel correct usage renders snapTypes 2`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: x mandatory;
   -moz-scroll-snap-type: x mandatory;
@@ -579,7 +579,7 @@ exports[`Reel correct usage renders snapTypes 3`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: x proximity;
   -moz-scroll-snap-type: x proximity;
@@ -623,7 +623,7 @@ exports[`Reel incorrect usage renders with console error with incorrect gutter 1
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;
@@ -667,7 +667,7 @@ exports[`Reel incorrect usage renders with console error with incorrect snapType
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   overflow-x: scroll;
   -webkit-scroll-snap-type: none;
   -moz-scroll-snap-type: none;

--- a/packages/reel/examples/Reel.stories.mdx
+++ b/packages/reel/examples/Reel.stories.mdx
@@ -28,7 +28,7 @@ yarn add @bedrock-layout/reel
 
 The `snapType` prop sets the scroll snap type.
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="snapType">
     <h3>none</h3>
     <p>scroll to the right to see the next item</p>
@@ -72,7 +72,7 @@ The `gutter` prop defines the spacing between elements. Bedrock has implemented 
 
 The following values are available by default:
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="gutter">
     <h3>none</h3>
     <Reel snapType="none" gutter="none">
@@ -207,7 +207,7 @@ export const Template = (args) =>  (
     </Reel>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     argTypes={argTypes}

--- a/packages/reel/src/index.tsx
+++ b/packages/reel/src/index.tsx
@@ -24,7 +24,7 @@ export const Reel = styled.div.attrs<ReelProps>((props) => {
   }
 
   display: flex;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
 
   overflow-x: scroll;
 

--- a/packages/split/__tests__/__snapshots__/split.test.js.snap
+++ b/packages/split/__tests__/__snapshots__/split.test.js.snap
@@ -5,7 +5,7 @@ exports[`Split correct usage renders all the fraction options 1`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: auto 1fr;
 }
 
@@ -37,7 +37,7 @@ exports[`Split correct usage renders all the fraction options 2`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr auto;
 }
 
@@ -69,7 +69,7 @@ exports[`Split correct usage renders all the fraction options 3`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 3fr;
 }
 
@@ -101,7 +101,7 @@ exports[`Split correct usage renders all the fraction options 4`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 2fr;
 }
 
@@ -133,7 +133,7 @@ exports[`Split correct usage renders all the fraction options 5`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -165,7 +165,7 @@ exports[`Split correct usage renders all the fraction options 6`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 2fr 1fr;
 }
 
@@ -197,7 +197,7 @@ exports[`Split correct usage renders all the fraction options 7`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 3fr 1fr;
 }
 
@@ -229,7 +229,7 @@ exports[`Split correct usage renders all the gutter options 1`] = `
   box-sizing: border-box;
   --gutter: 0px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -261,7 +261,7 @@ exports[`Split correct usage renders all the gutter options 2`] = `
   box-sizing: border-box;
   --gutter: 0.0625rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -293,7 +293,7 @@ exports[`Split correct usage renders all the gutter options 3`] = `
   box-sizing: border-box;
   --gutter: 0.125rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -325,7 +325,7 @@ exports[`Split correct usage renders all the gutter options 4`] = `
   box-sizing: border-box;
   --gutter: 0.25rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -357,7 +357,7 @@ exports[`Split correct usage renders all the gutter options 5`] = `
   box-sizing: border-box;
   --gutter: 0.5rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -389,7 +389,7 @@ exports[`Split correct usage renders all the gutter options 6`] = `
   box-sizing: border-box;
   --gutter: 0.75rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -421,7 +421,7 @@ exports[`Split correct usage renders all the gutter options 7`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -453,7 +453,7 @@ exports[`Split correct usage renders all the gutter options 8`] = `
   box-sizing: border-box;
   --gutter: 1.5rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -485,7 +485,7 @@ exports[`Split correct usage renders all the gutter options 9`] = `
   box-sizing: border-box;
   --gutter: 2rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -517,7 +517,7 @@ exports[`Split correct usage renders all the gutter options 10`] = `
   box-sizing: border-box;
   --gutter: 3rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -549,7 +549,7 @@ exports[`Split correct usage renders all the gutter options 11`] = `
   box-sizing: border-box;
   --gutter: 4rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -581,7 +581,7 @@ exports[`Split correct usage renders with theme overrides 1`] = `
   box-sizing: border-box;
   --gutter: 200px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -613,7 +613,7 @@ exports[`Split correct usage should render a split if container is above switchA
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -645,7 +645,7 @@ exports[`Split correct usage should render a split if container is above switchA
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -683,7 +683,7 @@ exports[`Split correct usage should render a stack if container is below switchA
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -721,7 +721,7 @@ exports[`Split correct usage should render as a main 1`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -753,7 +753,7 @@ exports[`Split correct usage should render as a main when wrapped in styled 1`] 
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -785,7 +785,7 @@ exports[`Split incorrect usage renders default with console error with fraction 
   box-sizing: border-box;
   --gutter: 0px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -817,7 +817,7 @@ exports[`Split incorrect usage renders default with console error with no gutter
   box-sizing: border-box;
   --gutter: 0px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -849,7 +849,7 @@ exports[`Split incorrect usage renders default with console error with wrong swi
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 
@@ -881,7 +881,7 @@ exports[`Split incorrect usage renders default with wrong gutter input 1`] = `
   box-sizing: border-box;
   --gutter: 0px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   grid-template-columns: 1fr 1fr;
 }
 

--- a/packages/split/examples/Split.stories.mdx
+++ b/packages/split/examples/Split.stories.mdx
@@ -28,7 +28,7 @@ yarn add @bedrock-layout/split
 
 The `fraction` prop defines the fraction of the container width to use for the split. You can use the following values:
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="fraction">
     <h3>1/4</h3>
     <Split gutter="lg" fraction="1/4">
@@ -76,7 +76,7 @@ The `gutter` prop defines the spacing between elements. Bedrock has implemented 
 
 The following values are available by default:
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="gutter">
     <h3>none</h3>
     <Split gutter="none" fraction="1/2">
@@ -140,7 +140,7 @@ The following values are available by default:
 
 The below example will switch the layout to stack when the width is less than `45rem`. (Resize your window to see this in action.)
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="With switchAt">
     <Split gutter="lg" fraction="1/2" switchAt="45rem">
       <Box />
@@ -160,7 +160,7 @@ export const Template = (args) =>  (
     </Split>
 );
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     argTypes={argTypes}

--- a/packages/split/src/index.tsx
+++ b/packages/split/src/index.tsx
@@ -53,7 +53,7 @@ const SplitBase = styled.div.attrs<SplitBaseProps>((props) => ({
   --gutter:${({ gutter, theme }) => getSpacingValue(theme, gutter) ?? "0px"};
 
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
   grid-template-columns: ${({ fraction = "1/2" }) =>
     fractions[fraction] ?? fractions["1/2"]}};
 `;

--- a/packages/stack/__tests__/__snapshots__/stack.test.js.snap
+++ b/packages/stack/__tests__/__snapshots__/stack.test.js.snap
@@ -5,7 +5,7 @@ exports[`Stack correct usage renders 0px with theme overrides 1`] = `
   box-sizing: border-box;
   --gutter: 0px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -43,7 +43,7 @@ exports[`Stack correct usage renders all the gutter options 1`] = `
   box-sizing: border-box;
   --gutter: 0px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -81,7 +81,7 @@ exports[`Stack correct usage renders all the gutter options 2`] = `
   box-sizing: border-box;
   --gutter: 0.0625rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -119,7 +119,7 @@ exports[`Stack correct usage renders all the gutter options 3`] = `
   box-sizing: border-box;
   --gutter: 0.125rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -157,7 +157,7 @@ exports[`Stack correct usage renders all the gutter options 4`] = `
   box-sizing: border-box;
   --gutter: 0.25rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -195,7 +195,7 @@ exports[`Stack correct usage renders all the gutter options 5`] = `
   box-sizing: border-box;
   --gutter: 0.5rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -233,7 +233,7 @@ exports[`Stack correct usage renders all the gutter options 6`] = `
   box-sizing: border-box;
   --gutter: 0.75rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -271,7 +271,7 @@ exports[`Stack correct usage renders all the gutter options 7`] = `
   box-sizing: border-box;
   --gutter: 1rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -309,7 +309,7 @@ exports[`Stack correct usage renders all the gutter options 8`] = `
   box-sizing: border-box;
   --gutter: 1.5rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -347,7 +347,7 @@ exports[`Stack correct usage renders all the gutter options 9`] = `
   box-sizing: border-box;
   --gutter: 2rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -385,7 +385,7 @@ exports[`Stack correct usage renders all the gutter options 10`] = `
   box-sizing: border-box;
   --gutter: 3rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -423,7 +423,7 @@ exports[`Stack correct usage renders all the gutter options 11`] = `
   box-sizing: border-box;
   --gutter: 4rem;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -461,7 +461,7 @@ exports[`Stack correct usage renders with theme overrides 1`] = `
   box-sizing: border-box;
   --gutter: 200px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -499,7 +499,7 @@ exports[`Stack correct usage renders with theme overrides using 'space' as key 1
   box-sizing: border-box;
   --gutter: 200px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;
@@ -537,7 +537,7 @@ exports[`Stack incorrect usage renders default with wrong input 1`] = `
   box-sizing: border-box;
   --gutter: 0px;
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter,0px);
   -webkit-align-content: start;
   -ms-flex-line-pack: start;
   align-content: start;

--- a/packages/stack/examples/Stack.stories.mdx
+++ b/packages/stack/examples/Stack.stories.mdx
@@ -30,7 +30,7 @@ The `gutter` prop defines the spacing between elements. Bedrock has implemented 
 
 The following values are available by default:
 
-<Canvas withToolbar withSource="open">
+<Canvas withSource="open">
   <Story name="Gutters">
     <h3>none</h3>
     <Stack gutter="none">
@@ -112,7 +112,7 @@ export const Template = (args) =>  (
     </Stack>
 )
 
-<Canvas withToolbar>
+<Canvas>
   <Story
     name="Playground"
     args={{

--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -21,7 +21,7 @@ export const Stack = styled.div.attrs<StackProps>(({ gutter, theme }) => {
   --gutter: ${(props) => getSpacingValue(props.theme, props.gutter) ?? "0px"};
 
   display: grid;
-  gap: var(--gutter);
+  gap: var(--gutter, 0px);
   align-content: start;
 
   & > [data-bedrock-column] {


### PR DESCRIPTION
The --switchAt property was set to not inherit, but it really needs to be inherited for everything
to work correctly