### PR TITLE
fix(inline): remove @property for minItemWidth

### DIFF
--- a/packages/bedrock-layout-css/src/components/column-drop.css
+++ b/packages/bedrock-layout-css/src/components/column-drop.css
@@ -8,12 +8,6 @@
   initial-value: 0;
 }
 
-@property --minItemWidth {
-  syntax: "<length-percentage>";
-  inherits: true;
-  initial-value: 159px;
-}
-
 [data-bedrock-column-drop] {
   box-sizing: border-box;
   display: flex;

--- a/packages/bedrock-layout-css/src/components/grid.css
+++ b/packages/bedrock-layout-css/src/components/grid.css
@@ -8,12 +8,6 @@
   initial-value: 0;
 }
 
-@property --minItemWidth {
-  syntax: "<length-percentage>";
-  inherits: false;
-  initial-value: 639px;
-}
-
 [data-bedrock-grid] {
   box-sizing: border-box;
   display: grid;

--- a/packages/bedrock-layout-css/src/components/inline.css
+++ b/packages/bedrock-layout-css/src/components/inline.css
@@ -13,12 +13,6 @@
   initial-value: 0;
 }
 
-@property --minItemWidth {
-  syntax: "<length-percentage>";
-  inherits: false;
-  initial-value: 0;
-}
-
 [data-bedrock-inline] {
   display: flex;
   flex-wrap: nowrap;
@@ -31,15 +25,16 @@
   margin: 0;
 }
 
-[data-bedrock-inline][style*="--minItemWidth"] > * {
-  min-inline-size: var(--minItemWidth, 0);
-}
-
 [data-bedrock-inline][style*="--switchAt"] {
   flex-wrap: wrap;
 }
+
 [data-bedrock-inline][style*="--switchAt"] > * {
   flex-basis: calc((var(--switchAt) - (100% - var(--gutter, 0px))) * 999);
+}
+
+[data-bedrock-inline][style*="--minItemWidth"] > * {
+  min-inline-size: var(--minItemWidth, 0);
 }
 
 [data-bedrock-inline~="justify:start"] {

--- a/packages/column-drop/src/index.tsx
+++ b/packages/column-drop/src/index.tsx
@@ -50,12 +50,6 @@ export const ColumnDrop = styled.div.attrs<ColumnDropProps>(
     };
   }
 )<ColumnDropProps>`
-  @property --minItemWidth {
-    syntax: "<length-percentage>";
-    inherits: true;
-    initial-value: ${sizes.xxsmall};
-  }
-
   @property --gutter {
     syntax: "<length-percentage>";
     inherits: false;

--- a/packages/grid/src/index.tsx
+++ b/packages/grid/src/index.tsx
@@ -41,12 +41,6 @@ export const Grid = styled.div.attrs<GridProps>(
     initial-value: 0;
   }
 
-  @property --minItemWidth {
-    syntax: "<length-percentage>";
-    inherits: false;
-    initial-value: ${sizes.small};
-  }
-
   box-sizing: border-box;
   > * {
     margin: 0;

--- a/packages/inline/src/index.tsx
+++ b/packages/inline/src/index.tsx
@@ -65,11 +65,7 @@ export const Inline = styled(InlineCluster).attrs<InlineProps>(
     inherits: true;
     initial-value: 0;
   }
-  @property --minItemWidth {
-    syntax: "<length-percentage>";
-    inherits: false;
-    initial-value: 0;
-  }
+
   flex-wrap: nowrap;
 
   > * {

--- a/packages/primitives/__tests__/__snapshots__/primitives.test.jsx.snap
+++ b/packages/primitives/__tests__/__snapshots__/primitives.test.jsx.snap
@@ -164,14 +164,6 @@ exports[`primitives > primitives snapshot 1`] = `
       "isStatic": false,
       "rules": [
         "
-  @property --minItemWidth {
-    syntax: \\"<length-percentage>\\";
-    inherits: true;
-    initial-value: ",
-        "159px",
-        ";
-  }
-
   @property --gutter {
     syntax: \\"<length-percentage>\\";
     inherits: false;
@@ -395,14 +387,6 @@ exports[`primitives > primitives snapshot 1`] = `
     initial-value: 0;
   }
 
-  @property --minItemWidth {
-    syntax: \\"<length-percentage>\\";
-    inherits: false;
-    initial-value: ",
-        "639px",
-        ";
-  }
-
   box-sizing: border-box;
   > * {
     margin: 0;
@@ -478,11 +462,7 @@ exports[`primitives > primitives snapshot 1`] = `
     inherits: true;
     initial-value: 0;
   }
-  @property --minItemWidth {
-    syntax: \\"<length-percentage>\\";
-    inherits: false;
-    initial-value: 0;
-  }
+
   flex-wrap: nowrap;
 
   > * {


### PR DESCRIPTION
The wrong type was provided to the @property which resulted in chrome not displaying the
min-item-width correctly