### PR TITLE
fix: fix document check in columns and types from polymorphic

### DIFF
--- a/packages/appboundary/src/index.tsx
+++ b/packages/appboundary/src/index.tsx
@@ -6,25 +6,16 @@ import {
   sizes,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React from "react";
 
 type BoundarySize = number | CSSLength | SizesOptions;
-interface AppBoundaryPropsBase {
+export interface AppBoundaryProps {
   boundarySize?: BoundarySize;
 }
 
-export type AppBoundaryProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, AppBoundaryPropsBase>;
-
-export const AppBoundary = forwardRef(
-  <C extends ElementType = "div">(
-    { as, boundarySize, children, style, ...props }: AppBoundaryProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export const AppBoundary = forwardRefWithAs<"div", AppBoundaryProps>(
+  ({ as, boundarySize, children, style, ...props }, ref) => {
     const theme = useTheme();
     const maybeSize = getSizeValue(theme, boundarySize);
     const safeStyle = style ?? {};

--- a/packages/center/src/index.tsx
+++ b/packages/center/src/index.tsx
@@ -4,35 +4,19 @@ import {
   getSizeValue,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { CSSProperties, ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React, { CSSProperties } from "react";
 
 type MaxWidth = number | CSSLength | SizesOptions;
 
-interface CenterPropsBase {
+export interface CenterProps {
   maxWidth?: MaxWidth;
   centerText?: boolean;
   centerChildren?: boolean;
 }
 
-export type CenterProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, CenterPropsBase>;
-
-export const Center = forwardRef(
-  <C extends ElementType = "div">(
-    {
-      as,
-      centerChildren,
-      centerText,
-      maxWidth,
-      style,
-      ...props
-    }: CenterProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export const Center = forwardRefWithAs<"div", CenterProps>(
+  ({ as, centerChildren, centerText, maxWidth, style, ...props }, ref) => {
     const theme = useTheme();
     const centerProps = [
       centerText && "center-text",

--- a/packages/column-drop/src/index.tsx
+++ b/packages/column-drop/src/index.tsx
@@ -6,22 +6,16 @@ import {
   getSizeValue,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { CSSProperties, ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React, { CSSProperties } from "react";
 
 type MinItemWidth = CSSLength | number | SizesOptions;
 
-interface ColumnDropPropsBase {
+export interface ColumnDropProps {
   gutter?: Gutter;
   minItemWidth?: MinItemWidth;
   noStretchedColumns?: boolean;
 }
-
-export type ColumnDropProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, ColumnDropPropsBase>;
 
 function getSafeMinItemWidth<T extends Record<string, unknown>>(
   theme: T,
@@ -30,17 +24,10 @@ function getSafeMinItemWidth<T extends Record<string, unknown>>(
   return getSizeValue(theme, minItemWidth);
 }
 
-export const ColumnDrop = forwardRef(
-  <C extends ElementType = "div">(
-    {
-      as,
-      gutter,
-      style,
-      minItemWidth,
-      noStretchedColumns = false,
-      ...props
-    }: ColumnDropProps<C>,
-    ref?: PolymorphicRef<C>
+export const ColumnDrop = forwardRefWithAs<"div", ColumnDropProps>(
+  (
+    { as, gutter, style, minItemWidth, noStretchedColumns = false, ...props },
+    ref
   ) => {
     const theme = useTheme();
     const maybeGutter = getSafeGutter(theme, gutter);

--- a/packages/cover/src/index.tsx
+++ b/packages/cover/src/index.tsx
@@ -6,23 +6,17 @@ import {
   getSizeValue,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { CSSProperties, ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React, { CSSProperties } from "react";
 
 type MinHeight = CSSLength | number | SizesOptions;
-interface CoverPropsBase {
+export interface CoverProps {
   top?: React.ReactNode;
   bottom?: React.ReactNode;
   gutter?: Gutter;
   minHeight?: MinHeight;
   stretchContent?: boolean;
 }
-
-export type CoverProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, CoverPropsBase>;
 
 function getSafeMinHeight<T extends Record<string, unknown>>(
   theme: T,
@@ -31,8 +25,8 @@ function getSafeMinHeight<T extends Record<string, unknown>>(
   return getSizeValue(theme, minHeight);
 }
 
-export const Cover = forwardRef(
-  <C extends ElementType = "div">(
+export const Cover = forwardRefWithAs<"div", CoverProps>(
+  (
     {
       as,
       children,
@@ -43,8 +37,8 @@ export const Cover = forwardRef(
       style,
       stretchContent,
       ...props
-    }: CoverProps<C>,
-    ref?: PolymorphicRef<C>
+    },
+    ref
   ) => {
     const theme = useTheme();
     const maybeGutter = getSafeGutter(theme, gutter);

--- a/packages/frame/src/index.tsx
+++ b/packages/frame/src/index.tsx
@@ -1,18 +1,12 @@
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { CSSProperties, ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React, { CSSProperties } from "react";
 type RatioString = `${number}/${number}` | `${number} / ${number}`;
 
 type Ratio = [number, number] | RatioString;
-interface FramePropsBase {
+export interface FrameProps {
   ratio?: Ratio;
   position?: string;
 }
-
-export type FrameProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, FramePropsBase>;
 
 function checkIsRatio(ratio: unknown): ratio is Ratio {
   const isCorrectArray =
@@ -34,11 +28,8 @@ function getSafeRatio(ratio: unknown): RatioString | undefined {
   return isRatio ? getRatioString(ratio) : undefined;
 }
 
-export const Frame = forwardRef(
-  <C extends ElementType = "div">(
-    { as, ratio, style, position, ...props }: FrameProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export const Frame = forwardRefWithAs<"div", FrameProps>(
+  ({ as, ratio, style, position, ...props }, ref) => {
     const safeRatio = getSafeRatio(ratio);
     const safeStyle = style ?? {};
 

--- a/packages/grid/src/index.tsx
+++ b/packages/grid/src/index.tsx
@@ -6,26 +6,17 @@ import {
   getSizeValue,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React from "react";
 
 type MinItemWidth = number | CSSLength | SizesOptions;
-interface GridPropsBase {
+export interface GridProps {
   gutter?: Gutter;
   minItemWidth?: MinItemWidth;
 }
 
-export type GridProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, GridPropsBase>;
-
-export const Grid = forwardRef(
-  <C extends ElementType = "div">(
-    { as, style, minItemWidth, gutter, ...props }: GridProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export const Grid = forwardRefWithAs<"div", GridProps>(
+  ({ as, style, minItemWidth, gutter, ...props }, ref) => {
     const theme = useTheme();
     const safeMinItemWidth = getSizeValue(theme, minItemWidth);
 

--- a/packages/inline-cluster/src/index.tsx
+++ b/packages/inline-cluster/src/index.tsx
@@ -3,26 +3,17 @@ import {
   getSafeGutter,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { CSSProperties, ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React, { CSSProperties } from "react";
 
-interface InlineClusterPropsBase {
+export interface InlineClusterProps {
   justify?: "start" | "end" | "center";
   align?: "start" | "end" | "center" | "stretch";
   gutter?: Gutter;
 }
 
-export type InlineClusterProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, InlineClusterPropsBase>;
-
-export const InlineCluster = forwardRef(
-  <C extends ElementType = "div">(
-    { as, justify, align, style, gutter, ...props }: InlineClusterProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export const InlineCluster = forwardRefWithAs<"div", InlineClusterProps>(
+  ({ as, justify, align, style, gutter, ...props }, ref) => {
     const theme = useTheme();
     const justifyValue = justify ? `justify:${justify}` : undefined;
     const alignValue = align ? `align:${align}` : undefined;

--- a/packages/inline/src/index.tsx
+++ b/packages/inline/src/index.tsx
@@ -7,17 +7,14 @@ import {
   getSizeValue,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { CSSProperties, ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React, { CSSProperties } from "react";
 
 type MinItemWidth = number | CSSLength | SizesOptions;
 type Stretch = "all" | "start" | "end" | number;
 type SwitchAt = CSSLength | number;
 
-export interface InlinePropsBase {
+export interface InlineProps {
   stretch?: Stretch;
   switchAt?: SwitchAt;
   minItemWidth?: MinItemWidth;
@@ -25,9 +22,6 @@ export interface InlinePropsBase {
   align?: "start" | "end" | "center" | "stretch";
   gutter?: Gutter;
 }
-
-export type InlineProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, InlinePropsBase>;
 
 function shouldUseSwitch(switchAt?: SwitchAt) {
   if (switchAt === undefined) {
@@ -39,8 +33,8 @@ function shouldUseSwitch(switchAt?: SwitchAt) {
     : switchAt > -1;
 }
 
-export const Inline = forwardRef(
-  <C extends ElementType = "div">(
+export const Inline = forwardRefWithAs<"div", InlineProps>(
+  (
     {
       as,
       justify,
@@ -51,8 +45,8 @@ export const Inline = forwardRef(
       switchAt,
       minItemWidth,
       ...props
-    }: InlineProps<C>,
-    ref?: PolymorphicRef<C>
+    },
+    ref
   ) => {
     const theme = useTheme();
     const justifyValue = justify ? `justify:${justify}` : undefined;

--- a/packages/masonry-grid/src/index.tsx
+++ b/packages/masonry-grid/src/index.tsx
@@ -4,13 +4,12 @@ import {
   getSafeGutter,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import { PolymorphicRef } from "@bedrock-layout/type-utils";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
 import { useResizeObserver } from "@bedrock-layout/use-resize-observer";
 import React, {
   CSSProperties,
   Children,
   ComponentPropsWithoutRef,
-  ElementType,
   cloneElement,
   forwardRef,
   useState,
@@ -75,11 +74,10 @@ const Resizer = ({
   );
 };
 
-export const MasonryGrid = forwardRef(
-  <C extends ElementType>(
-    { children, style, ...props }: GridProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export type MasonryGridProps = GridProps;
+
+export const MasonryGrid = forwardRefWithAs<"div", MasonryGridProps>(
+  ({ children, style, ...props }, ref) => {
     const safeStyle = style ?? {};
     return (
       <Grid

--- a/packages/padbox/src/index.tsx
+++ b/packages/padbox/src/index.tsx
@@ -9,6 +9,7 @@ import {
 import {
   PolymorphicComponentPropsWithRef,
   PolymorphicRef,
+  forwardRefWithAs,
 } from "@bedrock-layout/type-utils";
 import React, { CSSProperties, ElementType, forwardRef } from "react";
 
@@ -117,18 +118,12 @@ const paddingToStyleProps = (theme: BaseTheme, padding: PaddingTypes) => {
       };
 };
 
-interface PadBoxPropsBase {
+export interface PadBoxProps {
   padding?: PaddingTypes;
 }
 
-export type PadBoxProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, PadBoxPropsBase>;
-
-export const PadBox = forwardRef(
-  <C extends ElementType = "div">(
-    { as, style, padding, ...props }: PadBoxProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export const PadBox = forwardRefWithAs<"div", PadBoxProps>(
+  ({ as, style, padding, ...props }, ref) => {
     const theme = useTheme();
     const safeStyle = style ?? {};
 

--- a/packages/reel/src/index.tsx
+++ b/packages/reel/src/index.tsx
@@ -3,25 +3,16 @@ import {
   getSafeGutter,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { CSSProperties, ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React, { CSSProperties } from "react";
 
-interface ReelPropsBase {
+export interface ReelProps {
   snapType?: "none" | "proximity" | "mandatory";
   gutter?: Gutter;
 }
 
-export type ReelProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, ReelPropsBase>;
-
-export const Reel = forwardRef(
-  <C extends ElementType = "div">(
-    { as, snapType, gutter, style, ...props }: ReelProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export const Reel = forwardRefWithAs<"div", ReelProps>(
+  ({ as, snapType, gutter, style, ...props }, ref) => {
     const theme = useTheme();
     const maybeGutter = getSafeGutter(theme, gutter);
     const safeStyle = style ?? {};

--- a/packages/split/src/index.tsx
+++ b/packages/split/src/index.tsx
@@ -6,11 +6,8 @@ import {
   getSizeValue,
   useTheme,
 } from "@bedrock-layout/spacing-constants";
-import {
-  PolymorphicComponentPropsWithRef,
-  PolymorphicRef,
-} from "@bedrock-layout/type-utils";
-import React, { CSSProperties, ElementType, forwardRef } from "react";
+import { forwardRefWithAs } from "@bedrock-layout/type-utils";
+import React, { CSSProperties } from "react";
 
 type FractionTypes =
   | "auto-start"
@@ -36,29 +33,15 @@ const fractions: Fractions = {
 };
 
 type MinItemWidth = number | CSSLength | SizesOptions;
-interface SplitPropsBase {
+export interface SplitProps {
   gutter?: Gutter;
   fraction?: FractionTypes;
   switchAt?: number | CSSLength | SizesOptions;
   minItemWidth?: MinItemWidth;
 }
 
-export type SplitProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, SplitPropsBase>;
-
-export const Split = forwardRef(
-  <C extends ElementType = "div">(
-    {
-      as,
-      fraction,
-      gutter,
-      minItemWidth,
-      switchAt,
-      style,
-      ...props
-    }: SplitProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export const Split = forwardRefWithAs<"div", SplitProps>(
+  ({ as, fraction, gutter, minItemWidth, switchAt, style, ...props }, ref) => {
     const theme = useTheme();
     const attrString =
       fraction && fractions[fraction] ? `fraction:${fraction}` : "";

--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -6,21 +6,16 @@ import {
 import {
   PolymorphicComponentPropsWithRef,
   PolymorphicRef,
+  forwardRefWithAs,
 } from "@bedrock-layout/type-utils";
-import React, { ElementType, forwardRef } from "react";
+import React from "react";
 
-interface StackPropsBase {
+export interface StackProps {
   gutter?: Gutter;
 }
 
-export type StackProps<C extends ElementType = "div"> =
-  PolymorphicComponentPropsWithRef<C, StackPropsBase>;
-
-export const Stack = forwardRef(
-  <C extends ElementType = "div">(
-    { as, gutter, style, ...props }: StackProps<C>,
-    ref?: PolymorphicRef<C>
-  ) => {
+export const Stack = forwardRefWithAs<"div", StackProps>(
+  ({ as, gutter, style, ...props }, ref) => {
     const theme = useTheme();
     const maybeGutter = getSafeGutter(theme, gutter);
     const safeStyle = style ?? {};

--- a/packages/type-utils/src/index.tsx
+++ b/packages/type-utils/src/index.tsx
@@ -1,66 +1,70 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/ban-types */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-// Adapted from Source: https://www.benmvp.com/blog/forwarding-refs-polymorphic-react-component-typescript/
+// Adapted from Source: https://github.com/kripod/react-polymorphic-types/blob/main/index.d.ts
+// and https://www.benmvp.com/blog/forwarding-refs-polymorphic-react-component-typescript/
 import React from "react";
 
-// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
-// A more precise version of just React.ComponentPropsWithoutRef on its own
-export type PropsOf<
-  C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
-> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
+type Merge<T, U> = Omit<T, keyof U> & U;
 
-type AsProp<C extends React.ElementType> = {
-  /**
-   * An override of the default HTML tag.
-   * Can also be another React component.
-   */
-  as?: C;
-};
+type PropsWithAs<C extends React.ElementType, Props> = Props & { as?: C };
 
-/**
- * Allows for extending a set of props (`ExtendedProps`) by an overriding set of props
- * (`OverrideProps`), ensuring that any duplicates are overridden by the overriding
- * set of props.
- */
-export type ExtendableProps<
-  ExtendedProps = {},
-  OverrideProps = {}
-> = OverrideProps & Omit<ExtendedProps, keyof OverrideProps>;
-
-/**
- * Allows for inheriting the props from the specified element type so that
- * props like children, className & style work, as well as element-specific
- * attributes like aria roles. The component (`C`) must be passed in.
- */
-export type InheritableElementProps<
+export type PolymorphicComponentPropsWithoutRef<
   C extends React.ElementType,
-  Props = {}
-> = ExtendableProps<PropsOf<C>, Props>;
+  Props
+> = Merge<
+  C extends keyof JSX.IntrinsicElements
+    ? React.PropsWithoutRef<JSX.IntrinsicElements[C]>
+    : React.ComponentPropsWithoutRef<C>,
+  PropsWithAs<C, Props>
+>;
 
-/**
- * A more sophisticated version of `InheritableElementProps` where
- * the passed in `as` prop will determine which props can be included
- */
-export type PolymorphicComponentProps<
+export type PolymorphicComponentPropsWithRef<
   C extends React.ElementType,
-  Props = {}
-> = InheritableElementProps<C, Props & AsProp<C>>;
+  Props
+> = Merge<
+  C extends keyof JSX.IntrinsicElements
+    ? React.PropsWithRef<JSX.IntrinsicElements[C]>
+    : React.ComponentPropsWithRef<C>,
+  PropsWithAs<C, Props>
+>;
 
 /**
- * Utility type to extract the `ref` prop from a polymorphic component
+ * Utility type to create a component that can be used polymorphically
  */
+export type PolymorphicExoticComponent<
+  C extends React.ElementType = React.ElementType,
+  Props = {}
+> = Merge<
+  React.ExoticComponent<Props & { [key: string]: unknown }>,
+  {
+    /**
+     * **NOTE**: Exotic components are not callable.
+     */
+    <InstanceC extends React.ElementType = C>(
+      props: PolymorphicComponentPropsWithRef<InstanceC, Props>
+    ): React.ReactElement | null;
+  }
+>;
+
 export type PolymorphicRef<C extends React.ElementType> =
   React.ComponentPropsWithRef<C>["ref"];
 
 /**
- * Utility type to extend the `ref` prop from a polymorphic component
+ * Utility type to create a component that can be used polymorphically with Ref
  */
-export type WithRef<C extends React.ElementType> = { ref?: PolymorphicRef<C> };
-/**
- * A wrapper of `PolymorphicComponentProps` that also includes the `ref`
- * prop for the polymorphic component
- */
-export type PolymorphicComponentPropsWithRef<
+export type PolymorphicForwardedRefComponent<
   C extends React.ElementType,
-  Props = {}
-> = PolymorphicComponentProps<C, Props> & WithRef<C>;
+  Props
+> = Merge<
+  React.ForwardRefExoticComponent<Props & { [key: string]: unknown }>,
+  PolymorphicExoticComponent<C, Props>
+>;
+
+export function forwardRefWithAs<C extends React.ElementType, Props = {}>(
+  render: (
+    props: PolymorphicComponentPropsWithoutRef<C, Props>,
+    ref: PolymorphicRef<C>
+  ) => React.ReactElement | null
+) {
+  return React.forwardRef(render) as PolymorphicForwardedRefComponent<C, Props>;
+}


### PR DESCRIPTION
The polymorphic conversion was losing the types and SSR wasn't working with the columns component.
It now fixes both of those issues

fix #1596 fix #1589