### PR TITLE
fix(docs): fix links in docs site

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install dependencies
-        run: yarn config set registry https://registry.npmjs.org
         run: yarn
         # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic

--- a/.storybook/pages/Landing.stories.mdx
+++ b/.storybook/pages/Landing.stories.mdx
@@ -60,7 +60,7 @@ import { LocaleFab } from "../ui-components/LocaleFab";
         <img src='https://img.shields.io/github/stars/Bedrock-Layouts/Bedrock?style=social' alt='GitHub Repo stars'/>
       </Center>
       <Inline gutter="size3" justify="center" switchAt='20rem' minItemWidth="fit-content">
-        <Button primary as="a" href="/?path=/docs/getting-started-introduction--page">
+        <Button primary as="a" href="/?path=/docs/getting-started-introduction--docs">
           <Intl>landing:getStarted</Intl>
         </Button>
         <Button as="a" href="https://github.com/Bedrock-Layouts/Bedrock" target="__blank" rel="noreferer noopener">
@@ -113,14 +113,14 @@ export function Hero() {
 
 <p>
   <Intl>landing:composableLayout.description2</Intl>
-  <a href="/docs/examples-web-dev--12-span-grid#layout-patterns">
+  <a href="/?path=/docs/examples-web-dev--docs">
     <Intl>landing:composableLayout.exampleLink</Intl>
   </a>
 </p>
 
 <p>
   <Intl>landing:composableLayout.description3</Intl>
-  <a href="/docs/getting-started-introduction--page">
+  <a href="/?path=/docs/getting-started-introduction--docs">
     <Intl>landing:composableLayout.gettingStartedLink</Intl>
   </a>
 </p>
@@ -142,7 +142,7 @@ export function Hero() {
 
 <p>
   <Intl>landing:missingComponents.description2</Intl>
-  <a href="/docs/getting-started-spacing--page">
+  <a href="/?path=/docs/getting-started-lesson-3-spacing--docs">
     <Intl>landing:missingComponents.integrationLink</Intl>
   </a>
 </p>
@@ -205,7 +205,7 @@ export function Hero() {
 
 <p>
   <Intl>landing:notJustReact.description1</Intl>
-  <a href="/docs/css-only-a-css-only-version--page">
+  <a href="/?path=/docs/css-only-a-css-only-version--docs">
     <Intl>landing:notJustReact.cssOnlyLink</Intl>
   </a>
 </p>
@@ -227,7 +227,7 @@ export function Hero() {
 
 <p>
   <Intl>landing:gettingStarted.description1</Intl>
-  <a href="/docs/getting-started-introduction--page">
+  <a href="/docs/getting-started-introduction--docs">
     <Intl>landing:gettingStarted.gettingStartedLink</Intl>
   </a>
   <Intl>landing:gettingStarted.description2</Intl>
@@ -248,7 +248,7 @@ export function Hero() {
 
 <p>
   <Intl>landing:contribute.description1</Intl>
-  <a href="/docs/overview-contributing--page">
+  <a href="/?path=/docs/overview-contributing--docs">
     <Intl>landing:contribute.getInvolved</Intl>
   </a>
 </p>

--- a/.storybook/pages/hero.stories.mdx
+++ b/.storybook/pages/hero.stories.mdx
@@ -198,14 +198,14 @@ Our landing page is coming along. In the next section, we'll be building cards a
 <Inline switchAt="25rem" stretch={1} gutter="size3" minItemWidth="fit-content">
   <Button
     as="a"
-    href="/?path=/docs/getting-started-lesson-4-the-menu-component--page"
+    href="/?path=/docs/getting-started-lesson-4-the-menu-component--docs"
   >
     <Intl>The Menu Component</Intl>
   </Button>
   <span />
   <Button
     as="a"
-    href="/?path=/docs/getting-started-lesson-6-the-new-arrivals--page"
+    href="/?path=/docs/getting-started-lesson-6-the-new-arrivals--docs"
   >
     <Intl>The New Arrivals</Intl>
   </Button>

--- a/.storybook/pages/installation.stories.mdx
+++ b/.storybook/pages/installation.stories.mdx
@@ -75,13 +75,13 @@ Finally, let's start the development server by running `yarn start`. Navigate to
 We are now ready to start building our layout. In the next section, we will learn how to use the `Stack` component to create our first component in our landing page.
 
 <Inline switchAt="25rem" stretch={1} gutter="size3" minItemWidth="fit-content">
-  <Button as="a" href="/?path=/docs/getting-started-introduction--page">
+  <Button as="a" href="/?path=/docs/getting-started-introduction--docs">
     <Intl>Introduction</Intl>
   </Button>
   <span />
   <Button
     as="a"
-    href="/?path=/docs/getting-started-lesson-2-your-first-component--page"
+    href="/?path=/docs/getting-started-lesson-2-your-first-component--docs"
   >
     <Intl>Your First Component</Intl>
   </Button>

--- a/.storybook/pages/introduction.stories.mdx
+++ b/.storybook/pages/introduction.stories.mdx
@@ -74,7 +74,7 @@ In the following sections, we will be using Bedrock Layout Primitives to create 
   <span />
   <Button
     as="a"
-    href="/?path=/docs/getting-started-lesson-1-installation--page"
+    href="/?path=/docs/getting-started-lesson-1-installation--docs"
   >
     <Intl>Installation</Intl>
   </Button>

--- a/.storybook/pages/menu.stories.mdx
+++ b/.storybook/pages/menu.stories.mdx
@@ -162,11 +162,11 @@ Now if we resize to a small mobile screen size, it will look something like this
 In the next section we will start to fill out our landing page by adding a Hero section using the `Cover` component. I'll see you there.
 
 <Inline switchAt="25rem" stretch={1} gutter="size3" minItemWidth="fit-content">
-  <Button as="a" href="/?path=/docs/getting-started-lesson-3-spacing--page">
+  <Button as="a" href="/?path=/docs/getting-started-lesson-3-spacing--docs">
     <Intl>Spacing</Intl>
   </Button>
   <span />
-  <Button as="a" href="/?path=/docs/getting-started-lesson-5-the-hero--page">
+  <Button as="a" href="/?path=/docs/getting-started-lesson-5-the-hero--docs">
     <Intl>The Hero</Intl>
   </Button>
 </Inline>

--- a/.storybook/pages/new-arrivals.stories.mdx
+++ b/.storybook/pages/new-arrivals.stories.mdx
@@ -277,14 +277,14 @@ It's important to note that all three grid layouts will optimize based on it's c
 
 ## What Next?
 
-In just a few short lessons we now a well laid out landing page. You can see the power of how easy it is to create so many complicated layouts with these simple layout primitives. I recomend you check out the rest of the Bedrock Layout Primitives. Also check out the [CSS only version of the Bedrock Layout Primitives](/docs/css-only-a-css-only-version--page) in case you are interested in using them in a project that is not using React.
+In just a few short lessons we now a well laid out landing page. You can see the power of how easy it is to create so many complicated layouts with these simple layout primitives. I recomend you check out the rest of the Bedrock Layout Primitives. Also check out the [CSS only version of the Bedrock Layout Primitives](/docs/css-only-a-css-only-version--docs) in case you are interested in using them in a project that is not using React.
 
-If you are interested in contributing you can learn more about [contributing code to Bedrock](/docs/overview-contributing--page) or [you can open an issue any time at the GitHub repo](https://github.com/Bedrock-Layouts/Bedrock/issues).
+If you are interested in contributing you can learn more about [contributing code to Bedrock](/docs/overview-contributing--docs) or [you can open an issue any time at the GitHub repo](https://github.com/Bedrock-Layouts/Bedrock/issues).
 
 Thank you again for taking the time to learn more about Bedrock Layout Primitives. I hope you enjoyed it.
 
 <Inline gutter="size3" minItemWidth="fit-content">
-  <Button as="a" href="/?path=/docs/getting-started-lesson-5-the-hero--page">
+  <Button as="a" href="/?path=/docs/getting-started-lesson-5-the-hero--docs">
     <Intl>The Hero</Intl>
   </Button>
 </Inline>

--- a/.storybook/pages/spacing.stories.mdx
+++ b/.storybook/pages/spacing.stories.mdx
@@ -123,14 +123,14 @@ Now that we have our first component that stacks elements in the block direction
 <Inline switchAt="25rem" stretch={1} gutter="size3" minItemWidth="fit-content">
   <Button
     as="a"
-    href="/?path=/docs/getting-started-lesson-2-your-first-component--page"
+    href="/?path=/docs/getting-started-lesson-2-your-first-component--docs"
   >
     <Intl>Your First Component</Intl>
   </Button>
   <span />
   <Button
     as="a"
-    href="/?path=/docs/getting-started-lesson-4-the-menu-component--page"
+    href="/?path=/docs/getting-started-lesson-4-the-menu-component--docs"
   >
     <Intl>The Menu Component</Intl>
   </Button>

--- a/.storybook/pages/stack.stories.mdx
+++ b/.storybook/pages/stack.stories.mdx
@@ -144,12 +144,12 @@ The other part of the Stack primitive is the `gutter` prop. This allows you to c
 <Inline switchAt="25rem" stretch={1} gutter="size3" minItemWidth="fit-content">
   <Button
     as="a"
-    href="/?path=/docs/getting-started-lesson-1-installation--page"
+    href="/?path=/docs/getting-started-lesson-1-installation--docs"
   >
     <Intl>Installation</Intl>
   </Button>
   <span />
-  <Button as="a" href="/?path=/docs/getting-started-lesson-3-spacing--page">
+  <Button as="a" href="/?path=/docs/getting-started-lesson-3-spacing--docs">
     <Intl>Spacing</Intl>
   </Button>
 </Inline>

--- a/examples/web.dev.stories.mdx
+++ b/examples/web.dev.stories.mdx
@@ -95,7 +95,7 @@ At this time, Bedrock Layout Primitives does not have a layout component that wo
   </Story>
 </Canvas>
 
-[I am open to suggestions.](/?path=/docs/overview-contributing--page)
+[I am open to suggestions.](/?path=/docs/overview-contributing--docs)
 
 ## Deconstructed pancake
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 force = true
 from = "/src-components-use-forwarded-ref"
 status = 301
-to = "/?path=/docs/hooks-useforwardedref--page"
+to = "/?path=/docs/hooks-useforwardedref--docs"
 
 [[redirects]]
 force = true

--- a/netlifyhack.ts
+++ b/netlifyhack.ts
@@ -11,7 +11,17 @@ const netlifyToml = path.join(__dirname, "netlify.toml");
 
 (async () => {
   try {
-    await promisify(fs.rename)(hiddenStorybook, nonHiddenStorybook);
+    await promisify(fs.mkdir)(nonHiddenStorybook);
+    const hiddenStorybookFiles = await promisify(fs.readdir)(hiddenStorybook);
+
+    await Promise.all(
+      hiddenStorybookFiles.map(async (file) => {
+        const from = path.join(hiddenStorybook, file);
+        const to = path.join(nonHiddenStorybook, file);
+        await promisify(fs.copyFile)(from, to);
+      })
+    );
+
     const files = await promisify(fs.readdir)(sbAddons);
     if (!files.includes("storybook")) {
       throw new Error("Failed to rename .storybook to storybook");
@@ -22,7 +32,7 @@ const netlifyToml = path.join(__dirname, "netlify.toml");
 force = true
 from = "/src-components-use-forwarded-ref"
 status = 301
-to = "/?path=/docs/hooks-useforwardedref--page"
+to = "/?path=/docs/hooks-useforwardedref--docs"
 `;
     const tomlContent = storybookFiles.reduce((base, file) => {
       return `${base}

--- a/packages/column-drop/examples/ColumnDrop.stories.mdx
+++ b/packages/column-drop/examples/ColumnDrop.stories.mdx
@@ -30,7 +30,7 @@ yarn add @bedrock-layout/column-drop
 
 ## gutter
 
-The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--page#integrating-with-your-design-system)
+The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--docs#integrating-with-your-design-system)
 You can also use any valid CSSLength or positve integer.
 
 Here are the possible values for `gutter` by default:

--- a/packages/columns/examples/Columns.stories.mdx
+++ b/packages/columns/examples/Columns.stories.mdx
@@ -56,7 +56,7 @@ The below example gives us a 4 column layout. By default, each Component will ta
 
 ## gutters
 
-The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--page#integrating-with-your-design-system)
+The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--docs#integrating-with-your-design-system)
 You can also use any valid CSSLength or positve integer.
 
 Here are the possible values for `gutter` by default:

--- a/packages/cover/examples/Cover.stories.mdx
+++ b/packages/cover/examples/Cover.stories.mdx
@@ -129,7 +129,7 @@ The `minHeight` prop can be used to set the minimum height of the cover. The def
 
 ## gutter
 
-The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--page#integrating-with-your-design-system)
+The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--docs#integrating-with-your-design-system)
 You can also use any valid CSSLength or positve integer.
 
 Here are the possible values for `gutter` by default:

--- a/packages/css/examples/Stack.stories.mdx
+++ b/packages/css/examples/Stack.stories.mdx
@@ -7,7 +7,7 @@ import "../src/components/stack.css"
 
 # stack.css
 
-This is a CSS Only version of the [Stack package](/?path=/docs/components-stack--api).
+This is a CSS Only version of the [Stack package](/docs/spacer-components-stack--docs).
 
 ## Use case
 

--- a/packages/css/examples/center.stories.mdx
+++ b/packages/css/examples/center.stories.mdx
@@ -5,7 +5,7 @@ import "../src/components/center.css";
 
 # center.css
 
-This is a CSS Only version of the [Center package](/?path=/docs/components-center--api).
+This is a CSS Only version of the [Center package](/docs/wrapper-components-center--docs).
 
 ## Use case
 

--- a/packages/css/examples/column-drop.stories.mdx
+++ b/packages/css/examples/column-drop.stories.mdx
@@ -10,7 +10,7 @@ import "../src/components/column-drop.css"
 
 # column-drop.css
 
-This is a CSS Only version of the [ColumnDrop package](/?path=/docs/components-columndrop--api).
+This is a CSS Only version of the [ColumnDrop package](/docs/spacer-components-columndrop--docs).
 
 ## Use case
 

--- a/packages/css/examples/columns.stories.mdx
+++ b/packages/css/examples/columns.stories.mdx
@@ -10,7 +10,7 @@ import "../src/components/columns.css"
 
 # columns.css
 
-This is a CSS Only version of the [Column package](/?path=/docs/components-columns--api).
+This is a CSS Only version of the [Column package](/docs/spacer-components-columns--docs).
 
 ## Use case
 

--- a/packages/css/examples/cover.stories.mdx
+++ b/packages/css/examples/cover.stories.mdx
@@ -5,7 +5,7 @@ import "../src/components/cover.css"
 
 # cover.css
 
-This is a CSS Only version of the [Cover package](/?path=/docs/components-cover--api).
+This is a CSS Only version of the [Cover package](/docs/wrapper-components-cover--docs).
 
 ## Usage
 

--- a/packages/css/examples/frame.stories.mdx
+++ b/packages/css/examples/frame.stories.mdx
@@ -7,7 +7,7 @@ import imgSrc from '../../../.storybook/assets/data-pic.jpg'
 
 # frame.css
 
-This is a CSS Only version of the [Frame package](/?path=/docs/components-frame--api).
+This is a CSS Only version of the [Frame package](/docs/wrapper-components-frame--docs).
 
 ## Use case
 

--- a/packages/css/examples/grid.stories.mdx
+++ b/packages/css/examples/grid.stories.mdx
@@ -7,7 +7,7 @@ import "../src/components/grid.css"
 
 # grid.css
 
-This is a CSS Only version of the [Grid package](/?path=/docs/components-grid--api).
+This is a CSS Only version of the [Grid package](/docs/spacer-components-grid--docs).
 
 ## Use case
 

--- a/packages/css/examples/inline-cluster.stories.mdx
+++ b/packages/css/examples/inline-cluster.stories.mdx
@@ -10,7 +10,7 @@ import "../src/components/inline-cluster.css"
 
 # inline-cluster.css
 
-This is a CSS Only version of the [InlineCluster package](/?path=/docs/components-inlinecluster--api).
+This is a CSS Only version of the [InlineCluster package](/docs/spacer-components-inlinecluster--docs).
 
 ## Use case
 

--- a/packages/css/examples/inline.stories.mdx
+++ b/packages/css/examples/inline.stories.mdx
@@ -7,7 +7,7 @@ import "../src/components/inline.css"
 
 # inline.css
 
-This is a CSS Only version of the [Inline package](/?path=/docs/components-inline--api).
+This is a CSS Only version of the [Inline package](/docs/spacer-components-inline--docs).
 
 ## Use case
 

--- a/packages/css/examples/reel.stories.mdx
+++ b/packages/css/examples/reel.stories.mdx
@@ -7,7 +7,7 @@ import "../src/components/reel.css"
 
 # reel.css
 
-This is a CSS Only version of the [Reel package](/?path=/docs/components-reel--api).
+This is a CSS Only version of the [Reel package](/docs/spacer-components-reel--docs).
 
 ## Use case
 

--- a/packages/css/examples/split.stories.mdx
+++ b/packages/css/examples/split.stories.mdx
@@ -7,7 +7,7 @@ import "../src/components/split.css"
 
 # split.css
 
-This is a CSS Only version of the [Split package](/?path=/docs/components-split--api).
+This is a CSS Only version of the [Split package](/docs/spacer-components-split--docs).
 
 ## Use case
 

--- a/packages/grid/examples/Grid.stories.mdx
+++ b/packages/grid/examples/Grid.stories.mdx
@@ -30,7 +30,7 @@ yarn add @bedrock-layout/grid
 
 ## gutter
 
-The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--page#integrating-with-your-design-system)
+The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--docs#integrating-with-your-design-system)
 You can also use any valid CSSLength or positve integer.
 
 Here are the possible values for `gutter` by default:

--- a/packages/inline-cluster/examples/InlineCluster.stories.mdx
+++ b/packages/inline-cluster/examples/InlineCluster.stories.mdx
@@ -30,7 +30,7 @@ yarn add @bedrock-layout/inline-cluster
 
 ## gutter
 
-The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--page#integrating-with-your-design-system)
+The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--docs#integrating-with-your-design-system)
 You can also use any valid CSSLength or positve integer.
 
 Here are the possible values for `gutter` by default:

--- a/packages/reel/examples/Reel.stories.mdx
+++ b/packages/reel/examples/Reel.stories.mdx
@@ -71,7 +71,7 @@ The `snapType` prop sets the scroll snap type.
 
 ## gutter
 
-The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--page#integrating-with-your-design-system)
+The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--docs#integrating-with-your-design-system)
 You can also use any valid CSSLength or positve integer.
 
 Here are the possible values for `gutter` by default:

--- a/packages/split/examples/Split.stories.mdx
+++ b/packages/split/examples/Split.stories.mdx
@@ -76,7 +76,7 @@ The `fraction` prop defines the fraction of the container width to use for the s
 
 ## gutter
 
-The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--page#integrating-with-your-design-system)
+The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--docs#integrating-with-your-design-system)
 You can also use any valid CSSLength or positve integer.
 
 Here are the possible values for `gutter` by default:

--- a/packages/stack/examples/Stack.stories.mdx
+++ b/packages/stack/examples/Stack.stories.mdx
@@ -35,7 +35,7 @@ yarn add @bedrock-layout/stack
 
 ## gutter
 
-The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--page#integrating-with-your-design-system)
+The `gutter` prop defines the gutter size between elements. Bedrock has implemented a default spacing scheme, but [it can be overridden using the ThemeProvider provided by `@bedrock-layout/spacing-constants`.](/docs/spacing--docs#integrating-with-your-design-system)
 You can also use any valid CSSLength or positve integer.
 
 Here are the possible values for `gutter` by default:


### PR DESCRIPTION
Storybook 7 broke the existing links on the site.  This should fix them.

fix #1631