### PR TITLE
fix(split): split.css was staking too early

### DIFF
--- a/packages/css/src/components/split.css
+++ b/packages/css/src/components/split.css
@@ -60,7 +60,7 @@
   )
   > *:nth-child(even) {
   flex-basis: calc(
-    (max(var(--switchAt, 0px), var(--largestWidt)) - var(--largestWidth)) * 999
+    (max(var(--switchAt, 0px), var(--largestWidth)) - var(--largestWidth)) * 999
   );
   min-inline-size: max(
     min(var(--minItemWidth, 0), 100%),


### PR DESCRIPTION
split.css was using the wrong custom property