### PR TITLE
docs(docs): add table of contents

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -43,7 +43,8 @@ export const framework = {
 };
 
 export const docs = {
-  autodocs: true
+  autodocs: true,
+  toc: true,
 };
 
 function getAbsolutePath(value: string): any {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -17,6 +17,7 @@ export const parameters = {
       base: "dark",
     }),
     page: template,
+    toc: { disabled: false, headingSelector: "h2, h3" },
   },
   options: {
     storySort: {

--- a/stories/stack/Stack.stories.tsx
+++ b/stories/stack/Stack.stories.tsx
@@ -95,27 +95,27 @@ export const Playground: Story = {};
 export const Gutter: Story = {
   render: () => {
     return (
-      <>
-        <h3>Custom gutter as number (20)</h3>
+      <Stack gutter="size5">
+        <strong>Custom gutter as number (20)</strong>
         <Stack gutter={20}>
           <Component />
           <Component />
         </Stack>
-        <h3>Custom gutter as string ("3ch")</h3>
+        <strong>Custom gutter as string ("3ch")</strong>
         <Stack gutter="3ch">
           <Component />
           <Component />
         </Stack>
         {(Object.keys(spacing) as Array<keyof typeof spacing>).map((gutter) => (
           <React.Fragment key={gutter}>
-            <h3>{gutter}</h3>
+            <strong>{gutter}</strong>
             <Stack gutter={gutter}>
               <Component />
               <Component />
             </Stack>
           </React.Fragment>
         ))}
-      </>
+      </Stack>
     );
   },
 };


### PR DESCRIPTION
To make large doc pages easier, we will use the built in Table of Content option for storybook.

closes #2008