### PR TITLE
fix(masonry-grid): revert previous fix back to original

### DIFF
--- a/packages/masonry-grid/src/index.tsx
+++ b/packages/masonry-grid/src/index.tsx
@@ -12,7 +12,6 @@ import React, {
   ComponentPropsWithoutRef,
   cloneElement,
   forwardRef,
-  useEffect,
   useState,
 } from "react";
 
@@ -44,19 +43,9 @@ function Resizer({
 
   const theme = useTheme();
 
-  /* c8 ignore start */
-  const childRef = useResizeObserver<HTMLDivElement>(() => {
+  /* c8 ignore next */
+  const childRef = useResizeObserver<HTMLDivElement>(({ target }) => {
     setRowSpan(1);
-  });
-  /* c8 ignore end */
-
-  useEffect(() => {
-    if (!childRef.current) return;
-
-    const target = childRef.current;
-
-    target.style.blockSize = "1px";
-
     const gapString = getSafeGutter(theme, gutter) ?? "1px";
 
     const maybeGap = isBrowser ? toPX(gapString, target) : null;
@@ -64,21 +53,12 @@ function Resizer({
     const gap: number = Math.max(maybeGap ?? 1, 1);
 
     const [child] = Array.from(target.children);
+    const height = 1 + Math.min(target.scrollHeight, child.scrollHeight);
 
-    const [grandChild] = Array.from(child?.children ?? []);
+    const rowHeight = Math.ceil(height / gap);
 
-    const smallestScrollHeight = Math.min(
-      target.scrollHeight,
-      child?.scrollHeight ?? Number.MAX_SAFE_INTEGER,
-      grandChild?.scrollHeight ?? Number.MAX_SAFE_INTEGER,
-    );
-
-    const heightWithBuffer = gap / 3 + Math.max(1, smallestScrollHeight);
-
-    const newRowSpan = Math.max(1, Math.ceil(heightWithBuffer / gap));
-
-    setRowSpan(newRowSpan);
-  }, [rowSpan, childRef, theme, gutter]);
+    setRowSpan(rowHeight);
+  });
 
   return (
     <RowSpanner style={{ "--rows": rowSpan } as CSSProperties} ref={childRef}>


### PR DESCRIPTION
The previous masonry fix made things worse.  Reverting back to original logic.  closes #2057