### PR TITLE
feat(split): add stacking for items index 3+ for split

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "publish:fix": "lerna publish from-package",
     "verify": "yarn build && yarn check-types && yarn lint && yarn check-format && yarn test:coverage",
     "postinstall": "husky install",
-    "chromatic": "npx chromatic --build-script-name build:storybook --only-changed --project-token=$CHROMATIC_PROJECT_TOKEN"
+    "chromatic": "npx chromatic --build-script-name build:storybook --only-changed --untraced 'packages/primitives/package.json' --untraced 'package.json' --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
     "@reach/menu-button": "^0.18.0",

--- a/packages/css/src/components/split.css
+++ b/packages/css/src/components/split.css
@@ -6,7 +6,7 @@
   --switchAt: initial;
   --gutter: initial;
   --minItemWidth: initial;
-  --largestWidth: calc(100% - var(--gutter, 0px));
+  --largestWidth: calc(100% - max(0px, var(--gutter, 0px)));
   box-sizing: border-box;
   display: flex;
   flex-wrap: wrap;
@@ -20,38 +20,42 @@
   max-inline-size: unset;
 }
 
+[data-bedrock-split] > :nth-child(n + 2) ~ * {
+  flex-basis: 100%;
+}
+
 /* All the Fraction options */
-[data-bedrock-split~="fraction:1/4"] > *:nth-child(odd) {
+[data-bedrock-split~="fraction:1/4"] > *:nth-child(1) {
   flex-basis: max(var(--minItemWidth, 0px), calc(var(--largestWidth) * 0.25));
 }
 
-[data-bedrock-split~="fraction:1/3"] > *:nth-child(odd) {
+[data-bedrock-split~="fraction:1/3"] > *:nth-child(1) {
   flex-basis: max(
     var(--minItemWidth, 0px),
     calc(var(--largestWidth) * 0.333333)
   );
 }
 
-[data-bedrock-split~="fraction:1/2"] > *:nth-child(odd) {
+[data-bedrock-split~="fraction:1/2"] > *:nth-child(1) {
   flex-basis: max(var(--minItemWidth, 0px), calc(var(--largestWidth) * 0.5));
 }
 
-[data-bedrock-split~="fraction:2/3"] > *:nth-child(even) {
+[data-bedrock-split~="fraction:2/3"] > *:nth-child(2) {
   flex-basis: max(
     var(--minItemWidth, 0px),
     calc(var(--largestWidth) * 0.333333)
   );
 }
 
-[data-bedrock-split~="fraction:3/4"] > *:nth-child(even) {
+[data-bedrock-split~="fraction:3/4"] > *:nth-child(2) {
   flex-basis: max(var(--minItemWidth, 0px), calc(var(--largestWidth) * 0.25));
 }
 
-[data-bedrock-split~="fraction:auto-start"] > *:nth-child(odd) {
+[data-bedrock-split~="fraction:auto-start"] > *:nth-child(1) {
   flex-basis: var(--minItemWidth, 0);
 }
 
-[data-bedrock-split~="fraction:auto-end"] > *:nth-child(even) {
+[data-bedrock-split~="fraction:auto-end"] > *:nth-child(2) {
   flex-basis: var(--minItemWidth, 0);
 }
 
@@ -61,7 +65,7 @@
     [data-bedrock-split~="fraction:1/2"],
     [data-bedrock-split~="fraction:auto-start"]
   )
-  > *:nth-child(even) {
+  > *:nth-child(2) {
   flex-basis: calc(
     (max(var(--switchAt, 0px), var(--largestWidth)) - var(--largestWidth)) * 999
   );
@@ -77,7 +81,7 @@
     [data-bedrock-split~="fraction:2/3"],
     [data-bedrock-split~="fraction:auto-end"]
   )
-  > *:nth-child(odd) {
+  > *:nth-child(1) {
   flex-basis: calc(
     (var(--switchAt, var(--largestWidth)) - var(--largestWidth)) * 999
   );

--- a/stories/reel/Reel.stories.tsx
+++ b/stories/reel/Reel.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import { Stack } from "../../packages/stack/src/index";
 import { Reel } from "../../packages/reel/src/index";
-import { spacing } from "../../packages/spacing-constants/src/index";
+
 import { colors, ColoredRect } from "./colors";
 
 const installCode = `
@@ -30,7 +30,7 @@ const meta = {
       <Reel {...args}>
         {colors.map((color, ind) => {
           return (
-            <ColoredRect key={ind} bgColor={color}>
+            <ColoredRect key={ind} bgColor={color} style={{ minWidth: "70vw" }}>
               Lorem ipsum dolor sit amet.
             </ColoredRect>
           );
@@ -79,10 +79,10 @@ export const Playground: Story = {};
 export const Gutter: Story = {
   render: () => {
     return (
-      <Stack gutter="size5">
+      <Stack gutter="size5" style={{ maxInlineSize: "45ch" }}>
         <strong>Custom gutter as number (20)</strong>
         <Reel snapType="none" gutter={20}>
-          {colors.map((color, ind) => {
+          {colors.slice(0, colors.length / 4).map((color, ind) => {
             return (
               <ColoredRect key={ind} bgColor={color}>
                 Lorem ipsum dolor sit amet.{" "}
@@ -92,7 +92,7 @@ export const Gutter: Story = {
         </Reel>
         <strong>Custom gutter as string ("3ch")</strong>
         <Reel snapType="none" gutter="3ch">
-          {colors.map((color, ind) => {
+          {colors.slice(0, colors.length / 4).map((color, ind) => {
             return (
               <ColoredRect key={ind} bgColor={color}>
                 Lorem ipsum dolor sit amet.{" "}
@@ -100,11 +100,23 @@ export const Gutter: Story = {
             );
           })}
         </Reel>
-        {(Object.keys(spacing) as Array<keyof typeof spacing>).map((gutter) => (
+        <span>
+          (There is an issue with gutters rendering in the docs, but they work
+          in the playground above. Please see the{" "}
+          <a
+            href="https://github.com/Bedrock-Layouts/Bedrock/issues/2062"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://github.com/Bedrock-Layouts/Bedrock/issues/2062
+          </a>{" "}
+          for more information.)
+        </span>
+        {/* {(Object.keys(spacing) as Array<keyof typeof spacing>).map((gutter) => (
           <React.Fragment key={gutter}>
             <strong>{gutter}</strong>
             <Reel gutter={gutter} snapType="none">
-              {colors.map((color, ind) => {
+              {colors.slice(0, colors.length / 4).map((color, ind) => {
                 return (
                   <ColoredRect key={ind} bgColor={color}>
                     Lorem ipsum dolor sit amet.{" "}
@@ -113,7 +125,7 @@ export const Gutter: Story = {
               })}
             </Reel>
           </React.Fragment>
-        ))}
+        ))} */}
       </Stack>
     );
   },
@@ -148,7 +160,7 @@ export const SnapType: Story = {
         <Reel snapType="none" gutter="size3">
           {colors.map((color, i) => {
             return (
-              <ColoredRect key={i} bgColor={color} style={{ minWidth: "80%" }}>
+              <ColoredRect key={i} bgColor={color} style={{ minWidth: "70vw" }}>
                 Lorem ipsum dolor sit amet.
               </ColoredRect>
             );
@@ -158,7 +170,7 @@ export const SnapType: Story = {
         <Reel snapType="mandatory" gutter="size3">
           {colors.map((color, i) => {
             return (
-              <ColoredRect key={i} bgColor={color} style={{ minWidth: "80%" }}>
+              <ColoredRect key={i} bgColor={color} style={{ minWidth: "70vw" }}>
                 Lorem ipsum dolor sit amet.
               </ColoredRect>
             );
@@ -168,7 +180,7 @@ export const SnapType: Story = {
         <Reel snapType="proximity" gutter="size3">
           {colors.map((color, i) => {
             return (
-              <ColoredRect key={i} bgColor={color} style={{ minWidth: "80%" }}>
+              <ColoredRect key={i} bgColor={color} style={{ minWidth: "70vw" }}>
                 Lorem ipsum dolor sit amet.
               </ColoredRect>
             );

--- a/stories/split/Split.stories.tsx
+++ b/stories/split/Split.stories.tsx
@@ -248,3 +248,22 @@ export const SwitchAt: Story = {
     );
   },
 };
+/**
+ * The `Split` is designed to be used with a two children, but it can be used with more.
+ * If you use more than two children, the `Split` will stack all the children underneath the first two children.
+ */
+export const MoreThanTwoChildren: Story = {
+  args: {
+    fraction: "1/3",
+  },
+  render: (args) => {
+    return (
+      <Split {...args}>
+        <Component />
+        <Component />
+        <Component />
+        <Component />
+      </Split>
+    );
+  },
+};


### PR DESCRIPTION
Split is only designed for two children.  Before we did not try to accomodate if more than 2 items were added to a split.  But it should fail in a a responsible way.

Now, If you add more than 2 items to a split component it will stack below the 2 children above it.