### PR TITLE
fix: Ensure types are defined in ESM exports fields

### DIFF
--- a/packages/appboundary/package.json
+++ b/packages/appboundary/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/center/package.json
+++ b/packages/center/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/column-drop/package.json
+++ b/packages/column-drop/package.json
@@ -24,6 +24,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/columns/package.json
+++ b/packages/columns/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/cover/package.json
+++ b/packages/cover/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/frame/package.json
+++ b/packages/frame/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/inline-cluster/package.json
+++ b/packages/inline-cluster/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/inline/package.json
+++ b/packages/inline/package.json
@@ -24,6 +24,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/masonry-grid/package.json
+++ b/packages/masonry-grid/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/padbox/package.json
+++ b/packages/padbox/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -27,6 +27,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/reel/package.json
+++ b/packages/reel/package.json
@@ -24,6 +24,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/register-resize-callback/package.json
+++ b/packages/register-resize-callback/package.json
@@ -25,6 +25,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -35,6 +35,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/spacing-constants/package.json
+++ b/packages/spacing-constants/package.json
@@ -22,6 +22,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/split/package.json
+++ b/packages/split/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -23,6 +23,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/use-container-query/package.json
+++ b/packages/use-container-query/package.json
@@ -24,6 +24,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/use-forwarded-ref/package.json
+++ b/packages/use-forwarded-ref/package.json
@@ -24,6 +24,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/use-resize-observer/package.json
+++ b/packages/use-resize-observer/package.json
@@ -25,6 +25,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }

--- a/packages/use-stateful-ref/package.json
+++ b/packages/use-stateful-ref/package.json
@@ -24,6 +24,7 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/index.m.js",
       "require": "./lib/index.umd.js"
     }


### PR DESCRIPTION
**Problem:** When using `"moduleResolution": "bundler" with TypeScript and a package declares an `exports` field, all root level `main`, `module`, and `types` fields will be ignored. Using `exports` requires authors to _also_ include `types` values with each export, otherwise TS will fail to check/compile due to missing typedefs.

**Solution:** Add missing `types` key/val pairs to all `exports` declarations across every `package.json`