### PR TITLE
feat(grid): add masonry variant to grid component

### DIFF
--- a/packages/css/src/components/grid.css
+++ b/packages/css/src/components/grid.css
@@ -18,6 +18,11 @@
   margin: 0;
 }
 
+[data-bedrock-grid~="variant:masonry"] {
+  grid-template-rows: masonry;
+  masonry-auto-flow: next;
+}
+
 /* Gutter Sizes */
 [data-bedrock-grid~="gutter:size000"] {
   --gutter: -0.5rem;

--- a/packages/grid/__tests__/__snapshots__/grid.test.tsx.snap
+++ b/packages/grid/__tests__/__snapshots__/grid.test.tsx.snap
@@ -550,6 +550,31 @@ exports[`Grid > correct usage > renders default with no gutter 1`] = `
 </div>
 `;
 
+exports[`Grid > correct usage > renders masonry variant 1`] = `
+<div
+  data-bedrock-grid="variant:masonry"
+  style={
+    {
+      "--gutter": "1rem",
+      "--minItemWidth": "32rem",
+    }
+  }
+>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in vestibulum tortor, vitae venenatis lectus. Praesent gravida dapibus neque sit amet molestie. Morbi blandit eu dolor a luctus. Vestibulum sollicitudin elit ac nunc scelerisque rhoncus. Nulla felis sapien, condimentum ut imperdiet vel, aliquet id ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque ultrices, quam nec scelerisque malesuada, lectus elit semper diam, ac placerat purus tortor et enim.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in vestibulum tortor, vitae venenatis lectus. Praesent gravida dapibus neque sit amet molestie. Morbi blandit eu dolor a luctus. Vestibulum sollicitudin elit ac nunc scelerisque rhoncus. Nulla felis sapien, condimentum ut imperdiet vel, aliquet id ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque ultrices, quam nec scelerisque malesuada, lectus elit semper diam, ac placerat purus tortor et enim.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in vestibulum tortor, vitae venenatis lectus. Praesent gravida dapibus neque sit amet molestie. Morbi blandit eu dolor a luctus. Vestibulum sollicitudin elit ac nunc scelerisque rhoncus. Nulla felis sapien, condimentum ut imperdiet vel, aliquet id ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque ultrices, quam nec scelerisque malesuada, lectus elit semper diam, ac placerat purus tortor et enim.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in vestibulum tortor, vitae venenatis lectus. Praesent gravida dapibus neque sit amet molestie. Morbi blandit eu dolor a luctus. Vestibulum sollicitudin elit ac nunc scelerisque rhoncus. Nulla felis sapien, condimentum ut imperdiet vel, aliquet id ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque ultrices, quam nec scelerisque malesuada, lectus elit semper diam, ac placerat purus tortor et enim.
+  </p>
+</div>
+`;
+
 exports[`Grid > correct usage > renders with theme overrides 1`] = `
 <div
   data-bedrock-grid={true}
@@ -632,6 +657,31 @@ exports[`Grid > incorrect usage > renders default with wrong gutter input 1`] = 
     {
       "--gutter": undefined,
       "--minItemWidth": undefined,
+    }
+  }
+>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in vestibulum tortor, vitae venenatis lectus. Praesent gravida dapibus neque sit amet molestie. Morbi blandit eu dolor a luctus. Vestibulum sollicitudin elit ac nunc scelerisque rhoncus. Nulla felis sapien, condimentum ut imperdiet vel, aliquet id ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque ultrices, quam nec scelerisque malesuada, lectus elit semper diam, ac placerat purus tortor et enim.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in vestibulum tortor, vitae venenatis lectus. Praesent gravida dapibus neque sit amet molestie. Morbi blandit eu dolor a luctus. Vestibulum sollicitudin elit ac nunc scelerisque rhoncus. Nulla felis sapien, condimentum ut imperdiet vel, aliquet id ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque ultrices, quam nec scelerisque malesuada, lectus elit semper diam, ac placerat purus tortor et enim.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in vestibulum tortor, vitae venenatis lectus. Praesent gravida dapibus neque sit amet molestie. Morbi blandit eu dolor a luctus. Vestibulum sollicitudin elit ac nunc scelerisque rhoncus. Nulla felis sapien, condimentum ut imperdiet vel, aliquet id ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque ultrices, quam nec scelerisque malesuada, lectus elit semper diam, ac placerat purus tortor et enim.
+  </p>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in vestibulum tortor, vitae venenatis lectus. Praesent gravida dapibus neque sit amet molestie. Morbi blandit eu dolor a luctus. Vestibulum sollicitudin elit ac nunc scelerisque rhoncus. Nulla felis sapien, condimentum ut imperdiet vel, aliquet id ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque ultrices, quam nec scelerisque malesuada, lectus elit semper diam, ac placerat purus tortor et enim.
+  </p>
+</div>
+`;
+
+exports[`Grid > incorrect usage > renders grid if anything used as variant other than \`masonry\` 1`] = `
+<div
+  data-bedrock-grid={true}
+  style={
+    {
+      "--gutter": "1rem",
+      "--minItemWidth": "32rem",
     }
   }
 >

--- a/packages/grid/__tests__/grid.test.tsx
+++ b/packages/grid/__tests__/grid.test.tsx
@@ -85,6 +85,15 @@ describe("Grid", () => {
       expect(grid.toJSON()).toMatchSnapshot();
     });
 
+    it("renders masonry variant", () => {
+      const grid = create(
+        <Grid variant="masonry" gutter="size3" minItemWidth="32rem">
+          <Lorem />
+        </Grid>,
+      );
+      expect(grid.toJSON()).toMatchSnapshot();
+    });
+
     it("renders with theme overrides", () => {
       const grid = create(
         <ThemeProvider
@@ -135,6 +144,16 @@ describe("Grid", () => {
       );
 
       expect(errorStack.toJSON()).toMatchSnapshot();
+    });
+
+    it("renders grid if anything used as variant other than `masonry`", () => {
+      const grid = create(
+        // @ts-expect-error
+        <Grid variant="incorrect" gutter="size3" minItemWidth="32rem">
+          <Lorem />
+        </Grid>,
+      );
+      expect(grid.toJSON()).toMatchSnapshot();
     });
   });
 });

--- a/packages/grid/src/index.tsx
+++ b/packages/grid/src/index.tsx
@@ -27,6 +27,10 @@ export type GridProps = {
    * The `minItemWidth` prop can be a CSSLength, a number, or a key of the theme's sizes options.
    */
   minItemWidth?: MinItemWidth;
+  /**
+   * The `variant` prop can be set to "grid" or "masonry".
+   */
+  variant?: "grid" | "masonry";
 };
 
 /**
@@ -34,17 +38,26 @@ export type GridProps = {
  * that will automatically wrap based on the number of children and the `minItemWidth`.
  */
 export const Grid = forwardRefWithAs<"div", GridProps>(function Grid(
-  { as: Component = "div", style = {}, minItemWidth, gutter, ...props },
+  {
+    as: Component = "div",
+    style = {},
+    minItemWidth,
+    gutter,
+    variant,
+    ...props
+  },
   ref,
 ) {
   const theme = useTheme();
   const maybeMinItemWidth = getSizeValue(theme, minItemWidth);
   const maybeGutter = getSafeGutter(theme, gutter);
 
+  const attributeValue = variant === "masonry" ? "variant:masonry" : true;
+
   return (
     <Component
       ref={ref}
-      data-bedrock-grid
+      data-bedrock-grid={attributeValue}
       style={
         {
           "--minItemWidth": maybeMinItemWidth,

--- a/packages/masonry-grid/src/index.tsx
+++ b/packages/masonry-grid/src/index.tsx
@@ -88,6 +88,8 @@ export type MasonryGridProps = GridProps;
  * `MasonryGrid` does not create standard rows. Instead, it will
  * optimize for the most dense vertical layout that it can achieve based on
  * the space available.
+ *
+ * @deprecated Use the `Grid` component with the `variant` prop set to "masonry" instead.
  */
 export const MasonryGrid = forwardRefWithAs<"div", MasonryGridProps>(
   function MasonryGrid({ children, style = {}, ...props }, ref) {

--- a/packages/solid-doc-site/src/pages/GridPage/GridPage.tsx
+++ b/packages/solid-doc-site/src/pages/GridPage/GridPage.tsx
@@ -8,6 +8,8 @@ import { Story } from "../../components/Story";
 import { argTypes } from "./argTypes";
 import { Gutter } from "./gutters";
 import gutterCode from "./gutters?raw";
+import { MasonaryGrid } from "./masonaryGrid";
+import masonaryGridCode from "./masonaryGrid?raw";
 import { MinItemWidth } from "./minItemWidth";
 import minItemWidthCode from "./minItemWidth?raw";
 import { Playground } from "./playground";
@@ -61,6 +63,26 @@ export function GridPage(): JSXElement {
         </p>
         <Story code={minItemWidthCode}>
           <MinItemWidth />
+        </Story>
+      </PageSection>
+      <PageSection title="masonry Variant">
+        <p>
+          The variant prop can be set to "grid" or "masonry". The default value
+          is "grid". The masonry variant will optimize the layout of the
+          children based on the minItemWidth and the available block space.
+        </p>
+
+        <p>
+          <strong>Note:</strong> The masonry variant is a new feature coming to
+          CSS. It is not supported in all browsers yet. To see if the feature is
+          supported in your browser, check{" "}
+          <a href="https://caniuse.com/mdn-css_properties_grid-template-rows_masonry">
+            caniuse.com
+          </a>
+          .
+        </p>
+        <Story code={masonaryGridCode}>
+          <MasonaryGrid />
         </Story>
       </PageSection>
 

--- a/packages/solid-doc-site/src/pages/GridPage/argTypes.ts
+++ b/packages/solid-doc-site/src/pages/GridPage/argTypes.ts
@@ -10,6 +10,14 @@ export const argTypes: ArgType = {
     control: "select",
     options: Object.keys(spacing),
   },
+  variant: {
+    description: "Sets the variant of the grid to be default grid or masonry",
+    summary: "grid | masonry",
+    defaultValue: "grid",
+    initialValue: "grid",
+    control: "select",
+    options: ["grid", "masonry"],
+  },
   minItemWidth: {
     description: "Sets the basis of each of the children",
     summary: "CSSLength",

--- a/packages/solid-doc-site/src/pages/GridPage/masonaryGrid.tsx
+++ b/packages/solid-doc-site/src/pages/GridPage/masonaryGrid.tsx
@@ -1,14 +1,9 @@
-import React from "react";
-import styled from "styled-components";
-export const Component = styled.div`
-  background: black;
-  min-height: 50px;
-  min-width: 50px;
-`;
+import { Grid } from "@bedrock-layout/solid";
+import { JSXElement } from "solid-js";
 
-export function MasonryChildren() {
+export function MasonaryGrid(): JSXElement {
   return (
-    <>
+    <Grid variant="masonry" gutter="size3" minItemWidth="15rem">
       <div>
         1. Lorem ipsum dolor sit amet consectetur adipisicing elit. Fuga
         consequuntur corrupti beatae commodi vitae, perspiciatis totam provident
@@ -65,6 +60,6 @@ export function MasonryChildren() {
         ipsum. Donec ultrices vel nisi vehicula facilisis. Vestibulum cursus
         nisi tellus, sit amet sagittis nisl luctus ut.
       </div>
-    </>
+    </Grid>
   );
 }

--- a/packages/solid/src/grid.tsx
+++ b/packages/solid/src/grid.tsx
@@ -24,10 +24,11 @@ type MinItemWidth =
   | "min-content"
   | "auto";
 
-export interface GridBaseProps {
+export type GridBaseProps = {
   gutter?: SpacingOptions;
   minItemWidth?: MinItemWidth;
-}
+  variant?: "grid" | "masonry";
+};
 
 export type GridProps<T extends ValidConstructor = "div"> =
   HeadlessPropsWithRef<T, GridBaseProps>;
@@ -63,7 +64,8 @@ export function Grid<T extends ValidConstructor = "div">(
       omitProps(props, ["as", "gutter", "minItemWidth"]),
       createPropsFromAccessors({
         style,
-        "data-bedrock-grid": () => "",
+        "data-bedrock-grid": () =>
+          props.variant === "masonry" ? "variant:masonry" : "",
       }),
     ) as DynamicProps<T>,
   );

--- a/packages/solid/src/masonry-grid.tsx
+++ b/packages/solid/src/masonry-grid.tsx
@@ -76,6 +76,9 @@ const Resizer: Component<{ gutter?: SpacingOptions; children?: JSXElement }> = (
   );
 };
 
+/**
+ * @deprecated Use the `Grid` component with the `variant` prop set to "masonry" instead.
+ */
 export const MasonryGrid: Component<GridProps> = (props) => {
   const childrenMemo = children(() => props.children);
   const emptyResolvedChildren: ResolvedChildren = [];

--- a/stories/grid/Grid.stories.tsx
+++ b/stories/grid/Grid.stories.tsx
@@ -5,7 +5,7 @@ import { Grid } from "../../packages/grid/src/index";
 import { spacing } from "../../packages/spacing-constants/src/index";
 import { Stack } from "../../packages/stack/src/index";
 import { argTypes } from "./argTypes";
-import { Component } from "./Component";
+import { Component, MasonryChildren } from "./Component";
 
 const installCode = `
 ## For React.js
@@ -168,4 +168,44 @@ export const Gutter: Story = {
  *
  * (Resize window to observe the changes)
  */
+
 export const MinItemWidth: Story = {};
+
+/**
+ * The `variant` prop can be set to "grid" or "masonry". The default value is "grid".
+ * The `masonry` variant will optimize the layout of the children based on the `minItemWidth` and the available block space.
+ *
+ * **Note**: The `masonry` variant is a new feature coming to CSS.  It is not supported in all browsers yet. To see if the feature is supported in your browser, check [caniuse.com](https://caniuse.com/mdn-css_properties_grid-template-rows_masonry).
+ *
+ * #### Usage examples
+ * ```jsx
+ * // CSS
+ * <div data-bedrock-grid="variant:masonry" style={{--minItemWidth: '30ch'}}>
+ *   <Component />
+ *   <Component />
+ * </div>
+ *
+ * // React.js and Solid.js
+ * <Grid variant="masonry" minItemWidth="30ch">
+ *   <Component />
+ *   <Component />
+ * </Grid>
+ * ```
+ *
+ * In the below example, The `minItemWidth` is set to `15rem`. As you resize the
+ * window, the Grid will recalculate and potentially change the count of columns and rows.
+ *
+ * (Resize window to observe the changes)
+ */
+export const MasonryVariant: Story = {
+  args: {
+    variant: "masonry",
+  },
+  render: (args) => {
+    return (
+      <Grid {...args}>
+        <MasonryChildren />
+      </Grid>
+    );
+  },
+};

--- a/stories/grid/argTypes.ts
+++ b/stories/grid/argTypes.ts
@@ -21,6 +21,10 @@ export const argTypes = {
       "size15",
     ],
   },
+  variant: {
+    control: "select",
+    options: ["grid", "masonry"],
+  },
   minItemWidth: {
     control: "text",
   },


### PR DESCRIPTION
Adding a masonry variant to the grid css.  This will allow for future removal of the MasonryGrid
components and the extra JS needed to support them

re #2207