### PR TITLE
Fix broken image link in Landing.mdx

### DIFF
--- a/.storybook/pages/Landing.mdx
+++ b/.storybook/pages/Landing.mdx
@@ -288,7 +288,7 @@ export function Hero() {
   </a>
   <a href="https://twitter.com/chantastic" target="_blank">
     <Avatar
-      src="https://www.chromatic.com/team/portraits-chan-square.png"
+      src="https://pbs.twimg.com/profile_images/1646201135827501061/UGO77MZ8_400x400.png"
       alt="Michael Chan"
     />
   </a>


### PR DESCRIPTION
This pull request fixes a broken image link found in the following file:
Bedrock/.storybook/pages/Landing.mdx
I'd appreciate any feedback on my first open-source contribution